### PR TITLE
Upgrade gradle plugin from 0.12.+ to 0.13.2, Gradle wrapper 1.12 to 2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,13 +3,13 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.12.+'
+        classpath 'com.android.tools.build:gradle:0.13.2'
     }
 
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '1.12'
+    gradleVersion = '2.1'
 }
 
 allprojects {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Jun 23 11:59:55 BST 2013
+#Tue Oct 14 16:09:55 BST 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.1-all.zip


### PR DESCRIPTION
As the title says, updating gradle plugin and wrapper, before adding the new tasks for Bintray publish
