### PR TITLE
Adds check for connection to a specific network type

### DIFF
--- a/core/src/main/java/com/novoda/merlin/MerlinsBeard.java
+++ b/core/src/main/java/com/novoda/merlin/MerlinsBeard.java
@@ -10,6 +10,20 @@ import android.net.NetworkInfo;
  */
 public class MerlinsBeard {
 
+    public enum NetworkType {
+        WIFI(ConnectivityManager.TYPE_WIFI);
+
+        private final int networkType;
+
+        NetworkType(int networkType) {
+            this.networkType = networkType;
+        }
+
+        int getValue() {
+            return networkType;
+        }
+    }
+
     private ConnectivityManager connectivityManager;
 
     /**
@@ -36,10 +50,16 @@ public class MerlinsBeard {
      */
     public boolean isConnected() {
         NetworkInfo activeNetworkInfo = getNetworkInfo();
-        return (activeNetworkInfo != null && activeNetworkInfo.isConnected());
+        return activeNetworkInfo != null && activeNetworkInfo.isConnected();
     }
 
     private NetworkInfo getNetworkInfo() {
         return connectivityManager.getActiveNetworkInfo();
     }
+
+    public boolean isConnectedTo(NetworkType networkType) {
+        NetworkInfo networkInfo = connectivityManager.getNetworkInfo(networkType.getValue());
+        return networkInfo != null && networkInfo.isConnected();
+    }
+
 }

--- a/core/src/main/java/com/novoda/merlin/MerlinsBeard.java
+++ b/core/src/main/java/com/novoda/merlin/MerlinsBeard.java
@@ -57,6 +57,18 @@ public class MerlinsBeard {
         return connectivityManager.getActiveNetworkInfo();
     }
 
+    /**
+     * Provides a boolean representing whether a network connection of the type {@link com.novoda.merlin.MerlinsBeard.NetworkType}
+     * has been established.
+     *
+     * NOTE: Therefore available does not necessarily mean that an internet connection
+     * is available.
+     *
+     * @param networkType The network type {@link com.novoda.merlin.MerlinsBeard.NetworkType} to check whether there is a connection established
+     *
+     * @return boolean true if a network connection of the type of the type {@link com.novoda.merlin.MerlinsBeard.NetworkType}
+     * is available.
+     */
     public boolean isConnectedTo(NetworkType networkType) {
         NetworkInfo networkInfo = connectivityManager.getNetworkInfo(networkType.getValue());
         return networkInfo != null && networkInfo.isConnected();

--- a/core/src/main/java/com/novoda/merlin/MerlinsBeard.java
+++ b/core/src/main/java/com/novoda/merlin/MerlinsBeard.java
@@ -10,20 +10,6 @@ import android.net.NetworkInfo;
  */
 public class MerlinsBeard {
 
-    public enum NetworkType {
-        WIFI(ConnectivityManager.TYPE_WIFI);
-
-        private final int networkType;
-
-        NetworkType(int networkType) {
-            this.networkType = networkType;
-        }
-
-        int getValue() {
-            return networkType;
-        }
-    }
-
     private ConnectivityManager connectivityManager;
 
     /**
@@ -58,19 +44,15 @@ public class MerlinsBeard {
     }
 
     /**
-     * Provides a boolean representing whether a network connection of the type {@link com.novoda.merlin.MerlinsBeard.NetworkType}
-     * has been established.
+     * Provides a boolean representing whether a wifi network connection has been established.
      *
      * NOTE: Therefore available does not necessarily mean that an internet connection
      * is available.
      *
-     * @param networkType The network type {@link com.novoda.merlin.MerlinsBeard.NetworkType} to check whether there is a connection established
-     *
-     * @return boolean true if a network connection of the type of the type {@link com.novoda.merlin.MerlinsBeard.NetworkType}
-     * is available.
+     * @return boolean true if a wifi network connection is available.
      */
-    public boolean isConnectedTo(NetworkType networkType) {
-        NetworkInfo networkInfo = connectivityManager.getNetworkInfo(networkType.getValue());
+    public boolean isConnectedToWifi() {
+        NetworkInfo networkInfo = connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
         return networkInfo != null && networkInfo.isConnected();
     }
 

--- a/demo/src/main/java/com/novoda/merlin/demo/presentation/DemoActivity.java
+++ b/demo/src/main/java/com/novoda/merlin/demo/presentation/DemoActivity.java
@@ -15,6 +15,8 @@ import com.novoda.merlin.registerable.bind.Bindable;
 import com.novoda.merlin.registerable.connection.Connectable;
 import com.novoda.merlin.registerable.disconnection.Disconnectable;
 
+import static com.novoda.merlin.MerlinsBeard.NetworkType.WIFI;
+
 public class DemoActivity extends MerlinActivity implements Connectable, Disconnectable, Bindable {
 
     private NetworkStatusDisplayer networkStatusDisplayer;
@@ -28,6 +30,7 @@ public class DemoActivity extends MerlinActivity implements Connectable, Disconn
         merlinsBeard = MerlinsBeard.from(this);
 
         findViewById(R.id.current_status).setOnClickListener(networkStatusOnClick);
+        findViewById(R.id.wifi_connected).setOnClickListener(wifiConnectedOnClick);
     }
 
     private final View.OnClickListener networkStatusOnClick = new View.OnClickListener() {
@@ -44,6 +47,18 @@ public class DemoActivity extends MerlinActivity implements Connectable, Disconn
     private void showToast(int toastText) {
         Toast.makeText(this, toastText, Toast.LENGTH_SHORT).show();
     }
+
+    private final View.OnClickListener wifiConnectedOnClick = new View.OnClickListener() {
+
+        @Override
+        public void onClick(View view) {
+            if (merlinsBeard.isConnectedTo(WIFI)) {
+                showToast(R.string.toast_connected);
+            } else {
+                showToast(R.string.toast_disconnected);
+            }
+        }
+    };
 
     @Override
     protected Merlin createMerlin() {

--- a/demo/src/main/java/com/novoda/merlin/demo/presentation/DemoActivity.java
+++ b/demo/src/main/java/com/novoda/merlin/demo/presentation/DemoActivity.java
@@ -15,8 +15,6 @@ import com.novoda.merlin.registerable.bind.Bindable;
 import com.novoda.merlin.registerable.connection.Connectable;
 import com.novoda.merlin.registerable.disconnection.Disconnectable;
 
-import static com.novoda.merlin.MerlinsBeard.NetworkType.WIFI;
-
 public class DemoActivity extends MerlinActivity implements Connectable, Disconnectable, Bindable {
 
     private NetworkStatusDisplayer networkStatusDisplayer;
@@ -52,7 +50,7 @@ public class DemoActivity extends MerlinActivity implements Connectable, Disconn
 
         @Override
         public void onClick(View view) {
-            if (merlinsBeard.isConnectedTo(WIFI)) {
+            if (merlinsBeard.isConnectedToWifi()) {
                 showToast(R.string.toast_connected);
             } else {
                 showToast(R.string.toast_disconnected);

--- a/demo/src/main/res/layout/main.xml
+++ b/demo/src/main/res/layout/main.xml
@@ -12,4 +12,13 @@
     android:layout_centerVertical="true"
     android:text="@string/current_status" />
 
+  <Button
+    android:id="@+id/wifi_connected"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_centerHorizontal="true"
+    android:layout_centerVertical="true"
+    android:layout_below="@+id/current_status"
+    android:text="@string/is_wifi_connected" />
+
 </RelativeLayout>

--- a/demo/src/main/res/values/strings.xml
+++ b/demo/src/main/res/values/strings.xml
@@ -6,5 +6,6 @@
   <string name="current_status">Get Current Status</string>
   <string name="toast_connected">Connected</string>
   <string name="toast_disconnected">Disconnected</string>
+  <string name="is_wifi_connected">Is wifi connected</string>
 
 </resources>

--- a/unit-tests/src/test/java/com/novoda/merlin/MerlinsBeardShould.java
+++ b/unit-tests/src/test/java/com/novoda/merlin/MerlinsBeardShould.java
@@ -8,7 +8,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
-import static com.novoda.merlin.MerlinsBeard.NetworkType.*;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -56,25 +55,25 @@ public class MerlinsBeardShould {
 
     @Test
     public void returnTrueForIsConnectedToWifiWhenNetworkConnectedToWifiIsConnected() {
-        when(mockConnectivityManager.getNetworkInfo(WIFI.getValue())).thenReturn(mockNetworkInfo);
+        when(mockConnectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI)).thenReturn(mockNetworkInfo);
         when(mockNetworkInfo.isConnected()).thenReturn(true);
 
-        assertThat(merlinsBeard.isConnectedTo(WIFI)).isTrue();
+        assertThat(merlinsBeard.isConnectedToWifi()).isTrue();
     }
 
     @Test
     public void returnFalseForIsConnectedToWifiWhenNetworkConnectedToWifiIsNotConnected() {
-        when(mockConnectivityManager.getNetworkInfo(WIFI.getValue())).thenReturn(mockNetworkInfo);
+        when(mockConnectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI)).thenReturn(mockNetworkInfo);
         when(mockNetworkInfo.isConnected()).thenReturn(false);
 
-        assertThat(merlinsBeard.isConnectedTo(WIFI)).isFalse();
+        assertThat(merlinsBeard.isConnectedToWifi()).isFalse();
     }
 
     @Test
     public void returnFalseForIsConnectedToWifiWhenNetworkConnectionIsNotAvailable() {
-        when(mockConnectivityManager.getNetworkInfo(WIFI.getValue())).thenReturn(null);
+        when(mockConnectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI)).thenReturn(null);
 
-        assertThat(merlinsBeard.isConnectedTo(WIFI)).isFalse();
+        assertThat(merlinsBeard.isConnectedToWifi()).isFalse();
     }
 
 }

--- a/unit-tests/src/test/java/com/novoda/merlin/MerlinsBeardShould.java
+++ b/unit-tests/src/test/java/com/novoda/merlin/MerlinsBeardShould.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
+import static com.novoda.merlin.MerlinsBeard.NetworkType.*;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -51,6 +52,29 @@ public class MerlinsBeardShould {
         when(mockNetworkInfo.isConnected()).thenReturn(true);
 
         assertThat(merlinsBeard.isConnected()).isTrue();
+    }
+
+    @Test
+    public void returnTrueForIsConnectedToWifiWhenNetworkConnectedToWifiIsConnected() {
+        when(mockConnectivityManager.getNetworkInfo(WIFI.getValue())).thenReturn(mockNetworkInfo);
+        when(mockNetworkInfo.isConnected()).thenReturn(true);
+
+        assertThat(merlinsBeard.isConnectedTo(WIFI)).isTrue();
+    }
+
+    @Test
+    public void returnFalseForIsConnectedToWifiWhenNetworkConnectedToWifiIsNotConnected() {
+        when(mockConnectivityManager.getNetworkInfo(WIFI.getValue())).thenReturn(mockNetworkInfo);
+        when(mockNetworkInfo.isConnected()).thenReturn(false);
+
+        assertThat(merlinsBeard.isConnectedTo(WIFI)).isFalse();
+    }
+
+    @Test
+    public void returnFalseForIsConnectedToWifiWhenNetworkConnectionIsNotAvailable() {
+        when(mockConnectivityManager.getNetworkInfo(WIFI.getValue())).thenReturn(null);
+
+        assertThat(merlinsBeard.isConnectedTo(WIFI)).isFalse();
     }
 
 }


### PR DESCRIPTION
## Feature requested ##

A client needs to know whether a WIFI connection is available.

The current implementation checks if there is a connection established but it doesn't provide specifics about its type

## Solution implemented ##

We have created a new public method `isConnectedTo(...)` that accepts a `NetworkType` and checks if there is a valid connection against the provided type.

The demo application has been upgraded in order to provide a specific check for this new feature.

New types can be added by adding new ones to the new `enum` without any further code modification.

Tests are added in order to cover the new public method.

The current implemented service callback has not been modified as it is not necessary for the client.