### PR TITLE
Fix ConnectivityReceiver tests

### DIFF
--- a/core/src/main/java/com/novoda/merlin/receiver/ConnectivityReceiver.java
+++ b/core/src/main/java/com/novoda/merlin/receiver/ConnectivityReceiver.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.ConnectivityManager;
 import android.os.IBinder;
+import android.support.annotation.VisibleForTesting;
 
 import com.novoda.merlin.MerlinsBeard;
 import com.novoda.merlin.service.MerlinService;
@@ -29,7 +30,7 @@ public class ConnectivityReceiver extends BroadcastReceiver {
         if (intent.hasExtra(ConnectivityManager.EXTRA_NO_CONNECTIVITY)) {
             return !intent.getBooleanExtra(ConnectivityManager.EXTRA_NO_CONNECTIVITY, false);
         } else {
-            return MerlinsBeard.from(context).isConnected();
+            return getMerlinsBeard(context).isConnected();
         }
     }
 
@@ -44,12 +45,18 @@ public class ConnectivityReceiver extends BroadcastReceiver {
         return object != null;
     }
 
+    @VisibleForTesting
     protected MerlinService getMerlinService(Context context) {
         IBinder binder = peekService(context, new Intent(context, MerlinService.class));
         if (isAvailable(binder)) {
             return ((MerlinService.LocalBinder) binder).getService();
         }
         return null;
+    }
+
+    @VisibleForTesting
+    protected MerlinsBeard getMerlinsBeard(Context context) {
+        return MerlinsBeard.from(context);
     }
 
 }

--- a/core/src/test/java/com/novoda/merlin/receiver/ConnectivityReceiverShould.java
+++ b/core/src/test/java/com/novoda/merlin/receiver/ConnectivityReceiverShould.java
@@ -55,19 +55,20 @@ public class ConnectivityReceiverShould {
 
     @Test
     public void notNotifyTheMerlinServiceOnNonConnectivityIntents() throws Exception {
-        Intent intent = new Intent();
-        intent.setAction("notNotifyTheMerlinServiceOnNonConnectivityIntents");
-        connectivityReceiver.onReceive(context, intent);
+        Intent mockIntent = mock(Intent.class);
+        when(mockIntent.getAction()).thenReturn("notNotifyTheMerlinServiceOnNonConnectivityIntents");
+
+        connectivityReceiver.onReceive(context, mockIntent);
 
         verifyZeroInteractions(merlinService);
     }
 
     @Test
     public void notifyTheMerlinServiceOnValidConnectivityIntents() throws Exception {
-        Intent mock = mock(Intent.class);
-        when(mock.getAction()).thenReturn(ConnectivityManager.CONNECTIVITY_ACTION);
+        Intent mockIntent = mock(Intent.class);
+        when(mockIntent.getAction()).thenReturn(ConnectivityManager.CONNECTIVITY_ACTION);
 
-        connectivityReceiver.onReceive(context, mock);
+        connectivityReceiver.onReceive(context, mockIntent);
 
         verify(merlinService).onConnectivityChanged(any(ConnectivityChangeEvent.class));
     }

--- a/core/src/test/java/com/novoda/merlin/receiver/ConnectivityReceiverShould.java
+++ b/core/src/test/java/com/novoda/merlin/receiver/ConnectivityReceiverShould.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.net.ConnectivityManager;
 import android.test.mock.MockContext;
 
+import com.novoda.merlin.MerlinsBeard;
 import com.novoda.merlin.service.MerlinService;
 
 import org.junit.Before;
@@ -14,8 +15,7 @@ import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 @RunWith(JUnit4.class)
@@ -35,6 +35,13 @@ public class ConnectivityReceiverShould {
             @Override
             protected MerlinService getMerlinService(Context context) {
                 return merlinService;
+            }
+
+            @Override
+            protected MerlinsBeard getMerlinsBeard(Context context) {
+                MerlinsBeard mockMerlinsBeard = mock(MerlinsBeard.class);
+                when(mockMerlinsBeard.isConnected()).thenReturn(true);
+                return mockMerlinsBeard;
             }
         };
     }
@@ -57,10 +64,10 @@ public class ConnectivityReceiverShould {
 
     @Test
     public void notifyTheMerlinServiceOnValidConnectivityIntents() throws Exception {
-        Intent intent = new Intent();
-        intent.setAction(ConnectivityManager.CONNECTIVITY_ACTION);
+        Intent mock = mock(Intent.class);
+        when(mock.getAction()).thenReturn(ConnectivityManager.CONNECTIVITY_ACTION);
 
-        connectivityReceiver.onReceive(context, intent);
+        connectivityReceiver.onReceive(context, mock);
 
         verify(merlinService).onConnectivityChanged(any(ConnectivityChangeEvent.class));
     }


### PR DESCRIPTION
Fixes `ConnectivityReceiverShould#notifyTheMerlinServiceOnValidConnectivityIntents`:

```bash
Wanted but not invoked:
merlinService.onConnectivityChanged(<any>);
-> at com.novoda.merlin.receiver.ConnectivityReceiverShould.notifyTheMerlinServiceOnValidConnectivityIntents(ConnectivityReceiverShould.java:65)
Actually, there were zero interactions with this mock.
```