### PR TITLE
Refactor host pinger

### DIFF
--- a/core/src/main/java/com/novoda/merlin/service/HostPinger.java
+++ b/core/src/main/java/com/novoda/merlin/service/HostPinger.java
@@ -1,96 +1,53 @@
 package com.novoda.merlin.service;
 
-import android.os.AsyncTask;
-
-import com.novoda.merlin.MerlinLog;
 import com.novoda.merlin.Merlin;
+import com.novoda.merlin.MerlinLog;
 import com.novoda.merlin.service.request.MerlinRequest;
-import com.novoda.merlin.service.request.RequestException;
 
 class HostPinger {
 
     private final PingerCallback pingerCallback;
-    private final ResponseCodeFetcher responseCodeFetcher;
-
-    private String hostAddress;
+    private final String hostAddress;
+    private final PingTaskFactory pingTaskFactory;
 
     interface PingerCallback {
+
         void onSuccess();
 
         void onFailure();
+
     }
 
-    public HostPinger(PingerCallback pingerCallback) {
-        this(pingerCallback, new ResponseCodeFetcher());
+    public static HostPinger newInstance(PingerCallback pingerCallback) {
+        MerlinLog.d("Host address not set, using Merlin default : " + Merlin.DEFAULT_ENDPOINT);
+        return newInstance(pingerCallback, Merlin.DEFAULT_ENDPOINT);
     }
 
-    HostPinger(PingerCallback pingerCallback, ResponseCodeFetcher responseCodeFetcher) {
+    public static HostPinger newInstance(PingerCallback pingerCallback, String hostAddress) {
+        ResponseCodeFetcher responseCodeFetcher = new ResponseCodeFetcher();
+        PingTaskFactory pingTaskFactory = new PingTaskFactory(pingerCallback, responseCodeFetcher);
+        return new HostPinger(pingerCallback, hostAddress, pingTaskFactory);
+    }
+
+    HostPinger(PingerCallback pingerCallback, String hostAddress, PingTaskFactory pingTaskFactory) {
         this.pingerCallback = pingerCallback;
-        this.responseCodeFetcher = responseCodeFetcher;
-    }
-
-    public static class ResponseCodeFetcher {
-        public int from(String endpoint) {
-            return MerlinRequest.head(endpoint).getResponseCode();
-        }
-    }
-
-    public void setEndpoint(String endpoint) {
-        this.hostAddress = endpoint;
+        this.hostAddress = hostAddress;
+        this.pingTaskFactory = pingTaskFactory;
     }
 
     public void ping() {
-        PingTask pingTask = new PingTask(responseCodeFetcher, getHostAddress(), pingerCallback);
+        PingTask pingTask = pingTaskFactory.create(hostAddress);
         pingTask.execute();
-    }
-
-    private String getHostAddress() {
-        if (hostAddress == null) {
-            MerlinLog.d("Host address has not been set, using Merlin default : " + Merlin.DEFAULT_ENDPOINT);
-            return Merlin.DEFAULT_ENDPOINT;
-        }
-        return hostAddress;
     }
 
     public void noNetworkToPing() {
         pingerCallback.onFailure();
     }
 
-    private static class PingTask extends AsyncTask<Void, Void, Boolean> {
+    public static class ResponseCodeFetcher {
 
-        private static final int SUCCESS = 200;
-
-        private final ResponseCodeFetcher responseCodeFetcher;
-        private final String hostAddress;
-        private final PingerCallback pingerCallback;
-
-        PingTask(ResponseCodeFetcher responseCodeFetcher, String hostAddress, PingerCallback pingerCallback) {
-            this.responseCodeFetcher = responseCodeFetcher;
-            this.hostAddress = hostAddress;
-            this.pingerCallback = pingerCallback;
-        }
-
-        @Override
-        protected Boolean doInBackground(Void... params) {
-            try {
-                MerlinLog.d("Pinging : " + hostAddress);
-                int responseCode = responseCodeFetcher.from(hostAddress);
-                MerlinLog.d("Got response : " + responseCode);
-                return responseCode == SUCCESS;
-            } catch (RequestException e) {
-                MerlinLog.e("Ping task failed due to " + e.getMessage());
-                return false;
-            }
-        }
-
-        @Override
-        protected void onPostExecute(Boolean pingResult) {
-            super.onPostExecute(pingResult);
-            if (pingResult) {
-                pingerCallback.onSuccess();
-            } else {
-                pingerCallback.onFailure();
-            }
+        public int from(String endpoint) {
+            return MerlinRequest.head(endpoint).getResponseCode();
         }
 
     }

--- a/core/src/main/java/com/novoda/merlin/service/MerlinService.java
+++ b/core/src/main/java/com/novoda/merlin/service/MerlinService.java
@@ -22,7 +22,7 @@ public class MerlinService extends Service implements HostPinger.PingerCallback 
 
     private final IBinder binder;
     private CurrentNetworkStatusRetriever currentNetworkStatusRetriever;
-    private final HostPinger hostPinger;
+    private HostPinger hostPinger;
 
     private ConnectListener connectListener;
     private DisconnectListener disconnectListener;
@@ -31,7 +31,7 @@ public class MerlinService extends Service implements HostPinger.PingerCallback 
 
     public MerlinService() {
         binder = new LocalBinder();
-        hostPinger = new HostPinger(this);
+        hostPinger = HostPinger.newInstance(this);
     }
 
     @Override
@@ -78,7 +78,7 @@ public class MerlinService extends Service implements HostPinger.PingerCallback 
     }
 
     public void setHostname(String hostname) {
-        hostPinger.setEndpoint(hostname);
+        hostPinger = HostPinger.newInstance(this, hostname);
     }
 
     public void setBindStatusListener(BindListener bindListener) {

--- a/core/src/main/java/com/novoda/merlin/service/Ping.java
+++ b/core/src/main/java/com/novoda/merlin/service/Ping.java
@@ -1,0 +1,24 @@
+package com.novoda.merlin.service;
+
+import com.novoda.merlin.MerlinLog;
+
+class Ping {
+
+    private static final int SUCCESS = 200;
+
+    private final String hostAddress;
+    private final HostPinger.ResponseCodeFetcher responseCodeFetcher;
+
+    Ping(String hostAddress, HostPinger.ResponseCodeFetcher responseCodeFetcher) {
+        this.hostAddress = hostAddress;
+        this.responseCodeFetcher = responseCodeFetcher;
+    }
+
+    public boolean doSynchronousPing() {
+        MerlinLog.d("Pinging : " + hostAddress);
+        int responseCode = responseCodeFetcher.from(hostAddress);
+        MerlinLog.d("Got response : " + responseCode);
+        return responseCode == SUCCESS;
+    }
+
+}

--- a/core/src/main/java/com/novoda/merlin/service/PingTask.java
+++ b/core/src/main/java/com/novoda/merlin/service/PingTask.java
@@ -1,0 +1,38 @@
+package com.novoda.merlin.service;
+
+import android.os.AsyncTask;
+
+import com.novoda.merlin.MerlinLog;
+import com.novoda.merlin.service.request.RequestException;
+
+class PingTask extends AsyncTask<Void, Void, Boolean> {
+
+    private final Ping ping;
+    private final HostPinger.PingerCallback pingerCallback;
+
+    PingTask(Ping ping, HostPinger.PingerCallback pingerCallback) {
+        this.ping = ping;
+        this.pingerCallback = pingerCallback;
+    }
+
+    @Override
+    protected Boolean doInBackground(Void... params) {
+        try {
+            return ping.doSynchronousPing();
+        } catch (RequestException e) {
+            MerlinLog.e("Ping task failed due to " + e.getMessage());
+        }
+        return false;
+    }
+
+    @Override
+    protected void onPostExecute(Boolean pingResultIsSuccess) {
+        super.onPostExecute(pingResultIsSuccess);
+        if (pingResultIsSuccess) {
+            pingerCallback.onSuccess();
+        } else {
+            pingerCallback.onFailure();
+        }
+    }
+
+}

--- a/core/src/main/java/com/novoda/merlin/service/PingTaskFactory.java
+++ b/core/src/main/java/com/novoda/merlin/service/PingTaskFactory.java
@@ -1,0 +1,18 @@
+package com.novoda.merlin.service;
+
+class PingTaskFactory {
+
+    private final HostPinger.PingerCallback pingerCallback;
+    private final HostPinger.ResponseCodeFetcher responseCodeFetcher;
+
+    PingTaskFactory(HostPinger.PingerCallback pingerCallback, HostPinger.ResponseCodeFetcher responseCodeFetcher) {
+        this.pingerCallback = pingerCallback;
+        this.responseCodeFetcher = responseCodeFetcher;
+    }
+
+    public PingTask create(String hostAddress) {
+        Ping ping = new Ping(hostAddress, responseCodeFetcher);
+        return new PingTask(ping, pingerCallback);
+    }
+
+}

--- a/core/src/test/java/com/novoda/merlin/service/HostPingerShould.java
+++ b/core/src/test/java/com/novoda/merlin/service/HostPingerShould.java
@@ -1,69 +1,45 @@
 package com.novoda.merlin.service;
 
-import com.novoda.merlin.Merlin;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.Mock;
 
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 @RunWith(JUnit4.class)
 public class HostPingerShould {
 
-    public static final int SUCCESS_CODE = 200;
-    public static final int NON_SUCCESS_CODE = 201;
-
-    @Mock
-    private HostPinger.PingerCallback pingerCallback;
-    @Mock
-    private HostPinger.ResponseCodeFetcher responseCodeFetcher;
+    private static final String HOST_ADDRESS = "any host address";
 
     private HostPinger hostPinger;
+    private PingTaskFactory mockPingTaskFactory;
+    private PingTask mockPingTask;
 
     @Before
     public void setUp() throws Exception {
         initMocks(this);
-        hostPinger = new HostPinger(pingerCallback, responseCodeFetcher);
+
+        mockPingTask = mock(PingTask.class);
+        mockPingTaskFactory = mock(PingTaskFactory.class);
+        when(mockPingTaskFactory.create(HOST_ADDRESS)).thenReturn(mockPingTask);
+
+        hostPinger = new HostPinger(null, HOST_ADDRESS, mockPingTaskFactory);
     }
 
     @Test
-    public void callSuccessWhenHostResponseCodeIs200() throws Exception {
-        when(responseCodeFetcher.from(anyString())).thenReturn(SUCCESS_CODE);
-
+    public void createsPingTaskWhenPing() {
         hostPinger.ping();
 
-        verify(pingerCallback).onSuccess();
+        verify(mockPingTaskFactory).create(HOST_ADDRESS);
     }
 
     @Test
-    public void callFailureWhenHostResponseCodeIsNot200() throws Exception {
-        when(responseCodeFetcher.from(anyString())).thenReturn(NON_SUCCESS_CODE);
-
+    public void createsExecutesPingTaskWhenPing() {
         hostPinger.ping();
 
-        verify(pingerCallback).onFailure();
+        verify(mockPingTask).execute();
     }
 
-    @Test
-    public void pingAgainstAProvidedHostname() throws Exception {
-        String hostname = "pingAgainstAProvidedHostname";
-        hostPinger.setEndpoint(hostname);
-
-        hostPinger.ping();
-
-        verify(responseCodeFetcher).from(hostname);
-    }
-
-    @Test
-    public void useTheDefaultHostnameWhenNoHostnameIsSet() throws Exception {
-        hostPinger.ping();
-
-        verify(responseCodeFetcher).from(Merlin.DEFAULT_ENDPOINT);
-    }
 }

--- a/core/src/test/java/com/novoda/merlin/service/PingShould.java
+++ b/core/src/test/java/com/novoda/merlin/service/PingShould.java
@@ -1,0 +1,52 @@
+package com.novoda.merlin.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+@RunWith(JUnit4.class)
+public class PingShould {
+
+    public static final int SUCCESS_CODE = 200;
+    public static final int NON_SUCCESS_CODE = 201;
+    private static final String HOST_ADDRESS = "any host address";
+
+    @Mock
+    private HostPinger.PingerCallback mockPingerCallback;
+
+    @Mock
+    private HostPinger.ResponseCodeFetcher mockResponseCodeFetcher;
+
+    private Ping ping;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+        ping = new Ping(HOST_ADDRESS, mockResponseCodeFetcher);
+    }
+
+    @Test
+    public void returnsTrueWhenHostResponseCodeIsSuccess() throws Exception {
+        when(mockResponseCodeFetcher.from(HOST_ADDRESS)).thenReturn(SUCCESS_CODE);
+
+        boolean isSuccess = ping.doSynchronousPing();
+
+        assertThat(isSuccess).isTrue();
+    }
+
+    @Test
+    public void returnsFalseWhenHostResponseCodeIsNotSuccess() throws Exception {
+        when(mockResponseCodeFetcher.from(HOST_ADDRESS)).thenReturn(NON_SUCCESS_CODE);
+
+        boolean isSuccess = ping.doSynchronousPing();
+
+        assertThat(isSuccess).isFalse();
+    }
+
+}


### PR DESCRIPTION
The HostPinger tests were all failing because they were all dependent on HostPinger.PingTask (which extends AsyncTask -> all android classes are empty implementations).

- I extracted the logic from PingTask into a class called Ping, which does the call synchronously
- I made HostPinger immutable - previously the host name could be set. Instead, I create a new instance of HostPinger in MerlinService when someone wants to set the hostname.
- :exclamation: PingTask is still the one that triggers the callbacks onPostExecute(), and as such, **this is still untested**

This is the last set of test failures - once this is merged in, `migrate-to-android-unit-test` will be OK to merge into develop and make it greeeeen again.