### PR TITLE
Issue-27/Check for connection fails only if request fails

### DIFF
--- a/core/src/main/java/com/novoda/merlin/service/Ping.java
+++ b/core/src/main/java/com/novoda/merlin/service/Ping.java
@@ -16,8 +16,7 @@ class Ping {
     public boolean doSynchronousPing() {
         MerlinLog.d("Pinging : " + hostAddress);
         try {
-            int responseCode = responseCodeFetcher.from(hostAddress);
-            MerlinLog.d("Got response : " + responseCode);
+            responseCodeFetcher.from(hostAddress);
         } catch (RequestException e) {
             if (e.causedByIO()) {
                 return false;

--- a/core/src/main/java/com/novoda/merlin/service/Ping.java
+++ b/core/src/main/java/com/novoda/merlin/service/Ping.java
@@ -1,6 +1,7 @@
 package com.novoda.merlin.service;
 
 import com.novoda.merlin.MerlinLog;
+import com.novoda.merlin.service.request.RequestException;
 
 class Ping {
 
@@ -14,8 +15,16 @@ class Ping {
 
     public boolean doSynchronousPing() {
         MerlinLog.d("Pinging : " + hostAddress);
-        int responseCode = responseCodeFetcher.from(hostAddress);
-        MerlinLog.d("Got response : " + responseCode);
+        try {
+            int responseCode = responseCodeFetcher.from(hostAddress);
+            MerlinLog.d("Got response : " + responseCode);
+        } catch (RequestException e) {
+            if (e.causedByIO()) {
+                return false;
+            }
+
+            throw e;
+        }
         return true;
     }
 

--- a/core/src/main/java/com/novoda/merlin/service/Ping.java
+++ b/core/src/main/java/com/novoda/merlin/service/Ping.java
@@ -16,10 +16,7 @@ class Ping {
         MerlinLog.d("Pinging : " + hostAddress);
         int responseCode = responseCodeFetcher.from(hostAddress);
         MerlinLog.d("Got response : " + responseCode);
-        return isSuccess(responseCode);
+        return true;
     }
 
-    private static boolean isSuccess(int responseCode) {
-        return (responseCode >= 200 && responseCode < 300);
-    }
 }

--- a/core/src/main/java/com/novoda/merlin/service/request/RequestException.java
+++ b/core/src/main/java/com/novoda/merlin/service/request/RequestException.java
@@ -1,7 +1,13 @@
 package com.novoda.merlin.service.request;
 
+import java.io.IOException;
+
 public class RequestException extends RuntimeException {
-    RequestException(Throwable e) {
+    public RequestException(Throwable e) {
         super(e);
+    }
+
+    public boolean causedByIO() {
+        return getCause() instanceof IOException;
     }
 }

--- a/core/src/main/java/com/novoda/merlin/service/request/RequestException.java
+++ b/core/src/main/java/com/novoda/merlin/service/request/RequestException.java
@@ -3,6 +3,7 @@ package com.novoda.merlin.service.request;
 import java.io.IOException;
 
 public class RequestException extends RuntimeException {
+
     public RequestException(Throwable e) {
         super(e);
     }

--- a/core/src/test/java/com/novoda/merlin/service/PingShould.java
+++ b/core/src/test/java/com/novoda/merlin/service/PingShould.java
@@ -1,9 +1,13 @@
 package com.novoda.merlin.service;
 
+import com.novoda.merlin.service.request.RequestException;
+
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
@@ -65,6 +69,36 @@ public class PingShould {
                 }
                 return list;
             }
+        }
+    }
+
+    public static class GivenFailingRequest {
+
+        @Mock
+        private HostPinger.ResponseCodeFetcher mockResponseCodeFetcher;
+
+        private Ping ping;
+
+        @Before
+        public void setUp() {
+            initMocks(this);
+            ping = new Ping(HOST_ADDRESS, mockResponseCodeFetcher);
+        }
+
+        @Test
+        public void returnsFalseIfFailureIsBecauseIO() {
+            when(mockResponseCodeFetcher.from(HOST_ADDRESS)).thenThrow(new RequestException(new IOException()));
+
+            boolean isSuccess = ping.doSynchronousPing();
+
+            assertThat(isSuccess).isFalse();
+        }
+
+        @Test(expected = RequestException.class)
+        public void propagatesExceptionIfNotBecauseIO() {
+            when(mockResponseCodeFetcher.from(HOST_ADDRESS)).thenThrow(new RequestException(new RuntimeException()));
+
+            ping.doSynchronousPing();
         }
     }
 }


### PR DESCRIPTION
This addresses #27 making the check for `Ping` fail if the request fail, succeed otherwise, without taking care of the return code from the server.

Probably we can remove the log that shows the HTTP return code.

Tests added to reflect the changes.