### PR TITLE
MerlinsBeard#getMobileNetworkSubtypeName is documented

### DIFF
--- a/core/src/main/java/com/novoda/merlin/MerlinsBeard.java
+++ b/core/src/main/java/com/novoda/merlin/MerlinsBeard.java
@@ -69,6 +69,11 @@ public class MerlinsBeard {
         return networkInfo != null && networkInfo.isConnected();
     }
 
+    /**
+     * Provides a human-readable String describing the network subtype (e.g. UMTS, LTE) when connected to a mobile network.
+     *
+     * @return network subtype name, or empty string if not connected to a mobile network.
+     */
     public String getMobileNetworkSubtypeName() {
         NetworkInfo networkInfo = getNetworkInfo();
         if (networkInfo == null || !networkInfo.isConnected()) {


### PR DESCRIPTION
As described in https://github.com/novoda/merlin/issues/68 the public method getMobileNetworkSubtypeName on the MerlinsBeard class does not have any javadoc.

This PR adds some javadoc.

Paired with @alexstyl 