### PR TITLE
Support Android Marshmallow and above

### DIFF
--- a/core/src/main/java/com/novoda/merlin/MerlinBuilder.java
+++ b/core/src/main/java/com/novoda/merlin/MerlinBuilder.java
@@ -1,7 +1,13 @@
 package com.novoda.merlin;
 
+import android.annotation.TargetApi;
 import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.net.ConnectivityManager;
+import android.os.Build;
 
+import com.novoda.merlin.receiver.ConnectivityReceiver;
 import com.novoda.merlin.registerable.MerlinRegisterer;
 import com.novoda.merlin.registerable.Registerer;
 import com.novoda.merlin.registerable.bind.BindListener;
@@ -13,6 +19,7 @@ import com.novoda.merlin.registerable.connection.Connector;
 import com.novoda.merlin.registerable.disconnection.DisconnectListener;
 import com.novoda.merlin.registerable.disconnection.Disconnectable;
 import com.novoda.merlin.registerable.disconnection.Disconnector;
+import com.novoda.merlin.service.AndroidVersion;
 import com.novoda.merlin.service.MerlinService;
 import com.novoda.merlin.service.MerlinServiceBinder;
 import com.novoda.merlin.service.ResponseCodeValidator;
@@ -32,6 +39,7 @@ public class MerlinBuilder {
 
     private String endPoint = Merlin.DEFAULT_ENDPOINT;
     private ResponseCodeValidator responseCodeValidator = new DefaultEndpointResponseCodeValidator();
+    private AndroidVersion androidVersion = new AndroidVersion();
 
     MerlinBuilder() {
     }
@@ -157,8 +165,18 @@ public class MerlinBuilder {
                 endPoint,
                 responseCodeValidator
         );
+
+        if (androidVersion.isNougatOrHigher()) {
+            registerConnectivityReceiverForAndroidNougat(context);
+        }
+
         Registerer merlinRegisterer = new Registerer(connectableRegisterer, disconnectableRegisterer, bindableRegisterer);
         return new Merlin(merlinServiceBinder, merlinRegisterer, rxCallbacksManager);
+    }
+
+    @TargetApi(Build.VERSION_CODES.N)
+    private Intent registerConnectivityReceiverForAndroidNougat(Context context) {
+        return context.registerReceiver(new ConnectivityReceiver(), new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION));
     }
 
 }

--- a/core/src/main/java/com/novoda/merlin/MerlinsBeard.java
+++ b/core/src/main/java/com/novoda/merlin/MerlinsBeard.java
@@ -61,7 +61,7 @@ public class MerlinsBeard {
      */
     public boolean isConnectedToWifi() {
         if (androidVersion.isMarshmallowOrHigher()) {
-            return isConnectedToWifiForMarshmallow();
+            return connectedToNetworkTypeForMarshmallow(ConnectivityManager.TYPE_WIFI);
         } else {
             NetworkInfo networkInfo = connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
             return networkInfo != null && networkInfo.isConnected();
@@ -69,13 +69,13 @@ public class MerlinsBeard {
     }
 
     @TargetApi(Build.VERSION_CODES.M)
-    private boolean isConnectedToWifiForMarshmallow() {
+    private boolean connectedToNetworkTypeForMarshmallow(int networkType) {
         Network[] networks = connectivityManager.getAllNetworks();
 
         for (Network network : networks) {
             NetworkInfo networkInfo = connectivityManager.getNetworkInfo(network);
 
-            if (networkInfo.getType() == ConnectivityManager.TYPE_WIFI) {
+            if (networkInfo.getType() == networkType) {
                 return networkInfo.getState() == NetworkInfo.State.CONNECTED;
             }
 
@@ -93,8 +93,12 @@ public class MerlinsBeard {
      * @return boolean true if a mobile network connection is available.
      */
     public boolean isConnectedToMobileNetwork() {
-        NetworkInfo networkInfo = connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_MOBILE);
-        return networkInfo != null && networkInfo.isConnected();
+        if (androidVersion.isMarshmallowOrHigher()) {
+            return connectedToNetworkTypeForMarshmallow(ConnectivityManager.TYPE_MOBILE);
+        } else {
+            NetworkInfo networkInfo = connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_MOBILE);
+            return networkInfo != null && networkInfo.isConnected();
+        }
     }
 
     /**

--- a/core/src/main/java/com/novoda/merlin/MerlinsBeard.java
+++ b/core/src/main/java/com/novoda/merlin/MerlinsBeard.java
@@ -92,7 +92,7 @@ public class MerlinsBeard {
             NetworkInfo networkInfo = connectivityManager.getNetworkInfo(network);
 
             if (networkInfo.getType() == networkType) {
-                return networkInfo.getState() == NetworkInfo.State.CONNECTED;
+                return networkInfo.isConnected();
             }
 
         }

--- a/core/src/main/java/com/novoda/merlin/MerlinsBeard.java
+++ b/core/src/main/java/com/novoda/merlin/MerlinsBeard.java
@@ -52,6 +52,27 @@ public class MerlinsBeard {
     }
 
     /**
+     * Provides a boolean representing whether a mobile network connection has been established and is active.
+     * NOTE: Therefore available does not necessarily mean that an internet connection
+     * is available. Also, there can be only one network connection at a time, so this would return false if
+     * the active connection is the Wi-Fi one, even if there is a (inactive) mobile network connection established.
+     *
+     * @return boolean true if a mobile network connection is available.
+     */
+    public boolean isConnectedToMobileNetwork() {
+        return isConnectedTo(ConnectivityManager.TYPE_MOBILE);
+    }
+
+    private boolean isConnectedTo(int networkType) {
+        if (androidVersion.isMarshmallowOrHigher()) {
+            return connectedToNetworkTypeForMarshmallow(networkType);
+        } else {
+            NetworkInfo networkInfo = connectivityManager.getNetworkInfo(networkType);
+            return networkInfo != null && networkInfo.isConnected();
+        }
+    }
+
+    /**
      * Provides a boolean representing whether a Wi-Fi network connection has been established.
      * <p/>
      * NOTE: Therefore available does not necessarily mean that an internet connection
@@ -60,12 +81,7 @@ public class MerlinsBeard {
      * @return boolean true if a Wi-Fi network connection is available.
      */
     public boolean isConnectedToWifi() {
-        if (androidVersion.isMarshmallowOrHigher()) {
-            return connectedToNetworkTypeForMarshmallow(ConnectivityManager.TYPE_WIFI);
-        } else {
-            NetworkInfo networkInfo = connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
-            return networkInfo != null && networkInfo.isConnected();
-        }
+        return isConnectedTo(ConnectivityManager.TYPE_WIFI);
     }
 
     @TargetApi(Build.VERSION_CODES.M)
@@ -82,23 +98,6 @@ public class MerlinsBeard {
         }
 
         return false;
-    }
-
-    /**
-     * Provides a boolean representing whether a mobile network connection has been established and is active.
-     * NOTE: Therefore available does not necessarily mean that an internet connection
-     * is available. Also, there can be only one network connection at a time, so this would return false if
-     * the active connection is the Wi-Fi one, even if there is a (inactive) mobile network connection established.
-     *
-     * @return boolean true if a mobile network connection is available.
-     */
-    public boolean isConnectedToMobileNetwork() {
-        if (androidVersion.isMarshmallowOrHigher()) {
-            return connectedToNetworkTypeForMarshmallow(ConnectivityManager.TYPE_MOBILE);
-        } else {
-            NetworkInfo networkInfo = connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_MOBILE);
-            return networkInfo != null && networkInfo.isConnected();
-        }
     }
 
     /**

--- a/core/src/main/java/com/novoda/merlin/MerlinsBeard.java
+++ b/core/src/main/java/com/novoda/merlin/MerlinsBeard.java
@@ -66,10 +66,10 @@ public class MerlinsBeard {
     private boolean isConnectedTo(int networkType) {
         if (androidVersion.isMarshmallowOrHigher()) {
             return connectedToNetworkTypeForMarshmallow(networkType);
-        } else {
-            NetworkInfo networkInfo = connectivityManager.getNetworkInfo(networkType);
-            return networkInfo != null && networkInfo.isConnected();
         }
+
+        NetworkInfo networkInfo = connectivityManager.getNetworkInfo(networkType);
+        return networkInfo != null && networkInfo.isConnected();
     }
 
     /**

--- a/core/src/main/java/com/novoda/merlin/MerlinsBeard.java
+++ b/core/src/main/java/com/novoda/merlin/MerlinsBeard.java
@@ -63,15 +63,6 @@ public class MerlinsBeard {
         return isConnectedTo(ConnectivityManager.TYPE_MOBILE);
     }
 
-    private boolean isConnectedTo(int networkType) {
-        if (androidVersion.isMarshmallowOrHigher()) {
-            return connectedToNetworkTypeForMarshmallow(networkType);
-        }
-
-        NetworkInfo networkInfo = connectivityManager.getNetworkInfo(networkType);
-        return networkInfo != null && networkInfo.isConnected();
-    }
-
     /**
      * Provides a boolean representing whether a Wi-Fi network connection has been established.
      * <p/>
@@ -82,6 +73,15 @@ public class MerlinsBeard {
      */
     public boolean isConnectedToWifi() {
         return isConnectedTo(ConnectivityManager.TYPE_WIFI);
+    }
+
+    private boolean isConnectedTo(int networkType) {
+        if (androidVersion.isMarshmallowOrHigher()) {
+            return connectedToNetworkTypeForMarshmallow(networkType);
+        }
+
+        NetworkInfo networkInfo = connectivityManager.getNetworkInfo(networkType);
+        return networkInfo != null && networkInfo.isConnected();
     }
 
     @TargetApi(Build.VERSION_CODES.M)

--- a/core/src/main/java/com/novoda/merlin/service/AndroidVersion.java
+++ b/core/src/main/java/com/novoda/merlin/service/AndroidVersion.java
@@ -1,0 +1,21 @@
+package com.novoda.merlin.service;
+
+import android.os.Build;
+
+public class AndroidVersion {
+
+    private final int deviceVersion;
+
+    public AndroidVersion() {
+        this(Build.VERSION.SDK_INT);
+    }
+
+    private AndroidVersion(int deviceVersion) {
+        this.deviceVersion = deviceVersion;
+    }
+
+    public boolean isMarshmallowOrHigher() {
+        return deviceVersion >= Build.VERSION_CODES.M;
+    }
+
+}

--- a/core/src/main/java/com/novoda/merlin/service/AndroidVersion.java
+++ b/core/src/main/java/com/novoda/merlin/service/AndroidVersion.java
@@ -18,4 +18,7 @@ public class AndroidVersion {
         return deviceVersion >= Build.VERSION_CODES.M;
     }
 
+    public boolean isNougatOrHigher() {
+        return deviceVersion >= Build.VERSION_CODES.N;
+    }
 }

--- a/core/src/test/java/com/novoda/merlin/MerlinsBeardShould.java
+++ b/core/src/test/java/com/novoda/merlin/MerlinsBeardShould.java
@@ -94,7 +94,7 @@ public class MerlinsBeardShould {
     @TargetApi(Build.VERSION_CODES.M)
     @Test
     public void returnTrueForIsConnectedToWifiWhenNetworkConnectedToWifiIsConnectedAndAndroidVersionIsMarshmallowOrAbove() {
-        givenWifiNetworkState(NetworkInfo.State.CONNECTED);
+        givenNetworkState(NetworkInfo.State.CONNECTED, ConnectivityManager.TYPE_WIFI);
 
         boolean connectedToWifi = merlinsBeard.isConnectedToWifi();
 
@@ -104,7 +104,7 @@ public class MerlinsBeardShould {
     @TargetApi(Build.VERSION_CODES.M)
     @Test
     public void returnFalseForIsConnectedToWifiWhenNetworkConnectedToWifiIsNotConnectedAndAndroidVersionIsMarshmallowOrAbove() {
-        givenWifiNetworkState(NetworkInfo.State.DISCONNECTED);
+        givenNetworkState(NetworkInfo.State.DISCONNECTED, ConnectivityManager.TYPE_WIFI);
 
         boolean connectedToWifi = merlinsBeard.isConnectedToWifi();
 
@@ -121,17 +121,19 @@ public class MerlinsBeardShould {
     }
 
     @Test
-    public void returnTrueForIsConnectedToMobileWhenNetworkConnectedToMobileIsConnected() {
+    public void returnTrueForIsConnectedToMobileWhenNetworkConnectedToMobileIsConnectedAndAndroidVersionIsBelowMarshmallow() {
+        when(mockAndroidVersion.isMarshmallowOrHigher()).thenReturn(false);
         when(mockConnectivityManager.getNetworkInfo(ConnectivityManager.TYPE_MOBILE)).thenReturn(mockNetworkInfo);
         when(mockNetworkInfo.isConnected()).thenReturn(true);
 
-        boolean connectedToMobileNetwork = merlinsBeard.isConnectedToMobileNetwork();
+        boolean connectedToconnectedToMobileNetwork = merlinsBeard.isConnectedToMobileNetwork();
 
-        assertThat(connectedToMobileNetwork).isTrue();
+        assertThat(connectedToconnectedToMobileNetwork).isTrue();
     }
 
     @Test
-    public void returnFalseForIsConnectedToMobileWhenNetworkConnectedToMobileIsNotConnected() {
+    public void returnFalseForIsConnectedToMobileWhenNetworkConnectedToMobileIsNotConnectedAndAndroidVersionIsBelowMarshmallow() {
+        when(mockAndroidVersion.isMarshmallowOrHigher()).thenReturn(false);
         when(mockConnectivityManager.getNetworkInfo(ConnectivityManager.TYPE_MOBILE)).thenReturn(mockNetworkInfo);
         when(mockNetworkInfo.isConnected()).thenReturn(false);
 
@@ -140,20 +142,32 @@ public class MerlinsBeardShould {
         assertThat(connectedToMobileNetwork).isFalse();
     }
 
+    @TargetApi(Build.VERSION_CODES.M)
     @Test
-    public void returnFalseForIsConnectedToMobileWhenNetworkConnectionIsNotAvailable() {
-        when(mockConnectivityManager.getNetworkInfo(ConnectivityManager.TYPE_MOBILE)).thenReturn(null);
+    public void returnTrueForIsConnectedToMobileWhenNetworkConnectedToMobileIsConnectedAndAndroidVersionIsMarshmallowOrAbove() {
+        givenNetworkState(NetworkInfo.State.CONNECTED, ConnectivityManager.TYPE_MOBILE);
+
+        boolean connectedToMobileNetwork = merlinsBeard.isConnectedToMobileNetwork();
+
+        assertThat(connectedToMobileNetwork).isTrue();
+    }
+
+    @TargetApi(Build.VERSION_CODES.M)
+    @Test
+    public void returnFalseForIsConnectedToMobileWhenNetworkConnectedToMobileIsNotConnectedAndAndroidVersionIsMarshmallowOrAbove() {
+        givenNetworkState(NetworkInfo.State.DISCONNECTED, ConnectivityManager.TYPE_MOBILE);
 
         boolean connectedToMobileNetwork = merlinsBeard.isConnectedToMobileNetwork();
 
         assertThat(connectedToMobileNetwork).isFalse();
     }
 
-    private void givenWifiNetworkState(NetworkInfo.State state) {
+    @TargetApi(Build.VERSION_CODES.M)
+    private void givenNetworkState(NetworkInfo.State state, int networkType) {
         Network network = Mockito.mock(Network.class);
         NetworkInfo networkInfo = Mockito.mock(NetworkInfo.class);
         when(networkInfo.getState()).thenReturn(state);
-        when(networkInfo.getType()).thenReturn(ConnectivityManager.TYPE_WIFI);
+        when(networkInfo.getType()).thenReturn(networkType);
         when(mockConnectivityManager.getNetworkInfo(network)).thenReturn(networkInfo);
         when(mockAndroidVersion.isMarshmallowOrHigher()).thenReturn(true);
         when(mockConnectivityManager.getAllNetworks()).thenReturn(new Network[]{network});

--- a/core/src/test/java/com/novoda/merlin/MerlinsBeardShould.java
+++ b/core/src/test/java/com/novoda/merlin/MerlinsBeardShould.java
@@ -70,7 +70,7 @@ public class MerlinsBeardShould {
     }
 
     @Test
-    public void returnTrueForIsConnectedToWifiWhenNetworkConnectedToWifiIsConnectedAndAndroidVersionIsBelowMarshmallow() {
+    public void returnTrueWhenConnectedToWifiAndAndroidVersionIsBelowMarshmallow() {
         when(mockAndroidVersion.isMarshmallowOrHigher()).thenReturn(false);
         when(mockConnectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI)).thenReturn(mockNetworkInfo);
         when(mockNetworkInfo.isConnected()).thenReturn(true);
@@ -81,7 +81,7 @@ public class MerlinsBeardShould {
     }
 
     @Test
-    public void returnFalseForIsConnectedToWifiWhenNetworkConnectedToWifiIsNotConnectedAndAndroidVersionIsBelowMarshmallow() {
+    public void returnFalseWhenNotConnectedToWifiAndAndroidVersionIsBelowMarshmallow() {
         when(mockAndroidVersion.isMarshmallowOrHigher()).thenReturn(false);
         when(mockConnectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI)).thenReturn(mockNetworkInfo);
         when(mockNetworkInfo.isConnected()).thenReturn(false);
@@ -93,7 +93,7 @@ public class MerlinsBeardShould {
 
     @TargetApi(Build.VERSION_CODES.M)
     @Test
-    public void returnTrueForIsConnectedToWifiWhenNetworkConnectedToWifiIsConnectedAndAndroidVersionIsMarshmallowOrAbove() {
+    public void returnTrueWhenConnectedToWifiAndAndroidVersionIsMarshmallowOrAbove() {
         givenNetworkState(NetworkInfo.State.CONNECTED, ConnectivityManager.TYPE_WIFI);
 
         boolean connectedToWifi = merlinsBeard.isConnectedToWifi();
@@ -103,7 +103,7 @@ public class MerlinsBeardShould {
 
     @TargetApi(Build.VERSION_CODES.M)
     @Test
-    public void returnFalseForIsConnectedToWifiWhenNetworkConnectedToWifiIsNotConnectedAndAndroidVersionIsMarshmallowOrAbove() {
+    public void returnWhenConnectedToWifiAndAndroidVersionIsMarshmallowOrAbove() {
         givenNetworkState(NetworkInfo.State.DISCONNECTED, ConnectivityManager.TYPE_WIFI);
 
         boolean connectedToWifi = merlinsBeard.isConnectedToWifi();
@@ -112,7 +112,7 @@ public class MerlinsBeardShould {
     }
 
     @Test
-    public void returnFalseForIsConnectedToWifiWhenNetworkConnectionIsNotAvailable() {
+    public void returnFalseWhenConnectionIsNotAvailable() {
         when(mockConnectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI)).thenReturn(null);
 
         boolean connectedToWifi = merlinsBeard.isConnectedToWifi();
@@ -121,7 +121,7 @@ public class MerlinsBeardShould {
     }
 
     @Test
-    public void returnTrueForIsConnectedToMobileWhenNetworkConnectedToMobileIsConnectedAndAndroidVersionIsBelowMarshmallow() {
+    public void returnTrueWhenConnectedToMobileNetworkAndAndroidVersionIsBelowMarshmallow() {
         when(mockAndroidVersion.isMarshmallowOrHigher()).thenReturn(false);
         when(mockConnectivityManager.getNetworkInfo(ConnectivityManager.TYPE_MOBILE)).thenReturn(mockNetworkInfo);
         when(mockNetworkInfo.isConnected()).thenReturn(true);
@@ -132,7 +132,7 @@ public class MerlinsBeardShould {
     }
 
     @Test
-    public void returnFalseForIsConnectedToMobileWhenNetworkConnectedToMobileIsNotConnectedAndAndroidVersionIsBelowMarshmallow() {
+    public void returnFalseWhenNotConnectedToMobileNetworkAndAndroidVersionIsBelowMarshmallow() {
         when(mockAndroidVersion.isMarshmallowOrHigher()).thenReturn(false);
         when(mockConnectivityManager.getNetworkInfo(ConnectivityManager.TYPE_MOBILE)).thenReturn(mockNetworkInfo);
         when(mockNetworkInfo.isConnected()).thenReturn(false);
@@ -144,7 +144,7 @@ public class MerlinsBeardShould {
 
     @TargetApi(Build.VERSION_CODES.M)
     @Test
-    public void returnTrueForIsConnectedToMobileWhenNetworkConnectedToMobileIsConnectedAndAndroidVersionIsMarshmallowOrAbove() {
+    public void returnTrueWhenConnectedToMobileNetworkAndAndroidVersionIsMarshmallowOrAbove() {
         givenNetworkState(NetworkInfo.State.CONNECTED, ConnectivityManager.TYPE_MOBILE);
 
         boolean connectedToMobileNetwork = merlinsBeard.isConnectedToMobileNetwork();
@@ -154,7 +154,7 @@ public class MerlinsBeardShould {
 
     @TargetApi(Build.VERSION_CODES.M)
     @Test
-    public void returnFalseForIsConnectedToMobileWhenNetworkConnectedToMobileIsNotConnectedAndAndroidVersionIsMarshmallowOrAbove() {
+    public void returnFalseWhenNotConnectedToMobileNetworkAndAndroidVersionIsMarshmallowOrAbove() {
         givenNetworkState(NetworkInfo.State.DISCONNECTED, ConnectivityManager.TYPE_MOBILE);
 
         boolean connectedToMobileNetwork = merlinsBeard.isConnectedToMobileNetwork();

--- a/core/src/test/java/com/novoda/merlin/MerlinsBeardShould.java
+++ b/core/src/test/java/com/novoda/merlin/MerlinsBeardShould.java
@@ -22,6 +22,9 @@ import static org.mockito.MockitoAnnotations.initMocks;
 @RunWith(JUnit4.class)
 public class MerlinsBeardShould {
 
+    private static final boolean DISCONNECTED = false;
+    private static final boolean CONNECTED = true;
+
     @Mock
     private ConnectivityManager mockConnectivityManager;
 
@@ -94,7 +97,7 @@ public class MerlinsBeardShould {
     @TargetApi(Build.VERSION_CODES.M)
     @Test
     public void returnTrueWhenConnectedToWifiAndAndroidVersionIsMarshmallowOrAbove() {
-        givenNetworkState(NetworkInfo.State.CONNECTED, ConnectivityManager.TYPE_WIFI);
+        givenNetworkState(CONNECTED, ConnectivityManager.TYPE_WIFI);
 
         boolean connectedToWifi = merlinsBeard.isConnectedToWifi();
 
@@ -104,7 +107,7 @@ public class MerlinsBeardShould {
     @TargetApi(Build.VERSION_CODES.M)
     @Test
     public void returnWhenConnectedToWifiAndAndroidVersionIsMarshmallowOrAbove() {
-        givenNetworkState(NetworkInfo.State.DISCONNECTED, ConnectivityManager.TYPE_WIFI);
+        givenNetworkState(DISCONNECTED, ConnectivityManager.TYPE_WIFI);
 
         boolean connectedToWifi = merlinsBeard.isConnectedToWifi();
 
@@ -145,7 +148,7 @@ public class MerlinsBeardShould {
     @TargetApi(Build.VERSION_CODES.M)
     @Test
     public void returnTrueWhenConnectedToMobileNetworkAndAndroidVersionIsMarshmallowOrAbove() {
-        givenNetworkState(NetworkInfo.State.CONNECTED, ConnectivityManager.TYPE_MOBILE);
+        givenNetworkState(CONNECTED, ConnectivityManager.TYPE_MOBILE);
 
         boolean connectedToMobileNetwork = merlinsBeard.isConnectedToMobileNetwork();
 
@@ -155,7 +158,7 @@ public class MerlinsBeardShould {
     @TargetApi(Build.VERSION_CODES.M)
     @Test
     public void returnFalseWhenNotConnectedToMobileNetworkAndAndroidVersionIsMarshmallowOrAbove() {
-        givenNetworkState(NetworkInfo.State.DISCONNECTED, ConnectivityManager.TYPE_MOBILE);
+        givenNetworkState(DISCONNECTED, ConnectivityManager.TYPE_MOBILE);
 
         boolean connectedToMobileNetwork = merlinsBeard.isConnectedToMobileNetwork();
 
@@ -163,11 +166,11 @@ public class MerlinsBeardShould {
     }
 
     @TargetApi(Build.VERSION_CODES.M)
-    private void givenNetworkState(NetworkInfo.State state, int networkType) {
+    private void givenNetworkState(boolean isConnected, int networkType) {
         Network network = Mockito.mock(Network.class);
         NetworkInfo networkInfo = Mockito.mock(NetworkInfo.class);
-        when(networkInfo.getState()).thenReturn(state);
         when(networkInfo.getType()).thenReturn(networkType);
+        when(networkInfo.isConnected()).thenReturn(isConnected);
         when(mockConnectivityManager.getNetworkInfo(network)).thenReturn(networkInfo);
         when(mockAndroidVersion.isMarshmallowOrHigher()).thenReturn(true);
         when(mockConnectivityManager.getAllNetworks()).thenReturn(new Network[]{network});

--- a/core/src/test/java/com/novoda/merlin/MerlinsBeardShould.java
+++ b/core/src/test/java/com/novoda/merlin/MerlinsBeardShould.java
@@ -1,13 +1,19 @@
 package com.novoda.merlin;
 
+import android.annotation.TargetApi;
 import android.net.ConnectivityManager;
+import android.net.Network;
 import android.net.NetworkInfo;
+import android.os.Build;
+
+import com.novoda.merlin.service.AndroidVersion;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -22,13 +28,16 @@ public class MerlinsBeardShould {
     @Mock
     private NetworkInfo mockNetworkInfo;
 
+    @Mock
+    private AndroidVersion mockAndroidVersion;
+
     private MerlinsBeard merlinsBeard;
 
     @Before
     public void setUp() {
         initMocks(this);
 
-        merlinsBeard = new MerlinsBeard(mockConnectivityManager);
+        merlinsBeard = new MerlinsBeard(mockConnectivityManager, mockAndroidVersion);
     }
 
     @Test
@@ -36,14 +45,18 @@ public class MerlinsBeardShould {
         when(mockConnectivityManager.getActiveNetworkInfo()).thenReturn(mockNetworkInfo);
         when(mockNetworkInfo.isConnected()).thenReturn(false);
 
-        assertThat(merlinsBeard.isConnected()).isFalse();
+        boolean connected = merlinsBeard.isConnected();
+
+        assertThat(connected).isFalse();
     }
 
     @Test
     public void returnFalseForIsConnectedWhenNetworkConnectionIsNull() {
         when(mockConnectivityManager.getActiveNetworkInfo()).thenReturn(null);
 
-        assertThat(merlinsBeard.isConnected()).isFalse();
+        boolean connected = merlinsBeard.isConnected();
+
+        assertThat(connected).isFalse();
     }
 
     @Test
@@ -51,30 +64,60 @@ public class MerlinsBeardShould {
         when(mockConnectivityManager.getActiveNetworkInfo()).thenReturn(mockNetworkInfo);
         when(mockNetworkInfo.isConnected()).thenReturn(true);
 
-        assertThat(merlinsBeard.isConnected()).isTrue();
+        boolean connected = merlinsBeard.isConnected();
+
+        assertThat(connected).isTrue();
     }
 
     @Test
-    public void returnTrueForIsConnectedToWifiWhenNetworkConnectedToWifiIsConnected() {
+    public void returnTrueForIsConnectedToWifiWhenNetworkConnectedToWifiIsConnectedAndAndroidVersionIsBelowMarshmallow() {
+        when(mockAndroidVersion.isMarshmallowOrHigher()).thenReturn(false);
         when(mockConnectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI)).thenReturn(mockNetworkInfo);
         when(mockNetworkInfo.isConnected()).thenReturn(true);
 
-        assertThat(merlinsBeard.isConnectedToWifi()).isTrue();
+        boolean connectedToWifi = merlinsBeard.isConnectedToWifi();
+
+        assertThat(connectedToWifi).isTrue();
     }
 
     @Test
-    public void returnFalseForIsConnectedToWifiWhenNetworkConnectedToWifiIsNotConnected() {
+    public void returnFalseForIsConnectedToWifiWhenNetworkConnectedToWifiIsNotConnectedAndAndroidVersionIsBelowMarshmallow() {
+        when(mockAndroidVersion.isMarshmallowOrHigher()).thenReturn(false);
         when(mockConnectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI)).thenReturn(mockNetworkInfo);
         when(mockNetworkInfo.isConnected()).thenReturn(false);
 
-        assertThat(merlinsBeard.isConnectedToWifi()).isFalse();
+        boolean connectedToWifi = merlinsBeard.isConnectedToWifi();
+
+        assertThat(connectedToWifi).isFalse();
+    }
+
+    @TargetApi(Build.VERSION_CODES.M)
+    @Test
+    public void returnTrueForIsConnectedToWifiWhenNetworkConnectedToWifiIsConnectedAndAndroidVersionIsMarshmallowOrAbove() {
+        givenWifiNetworkState(NetworkInfo.State.CONNECTED);
+
+        boolean connectedToWifi = merlinsBeard.isConnectedToWifi();
+
+        assertThat(connectedToWifi).isTrue();
+    }
+
+    @TargetApi(Build.VERSION_CODES.M)
+    @Test
+    public void returnFalseForIsConnectedToWifiWhenNetworkConnectedToWifiIsNotConnectedAndAndroidVersionIsMarshmallowOrAbove() {
+        givenWifiNetworkState(NetworkInfo.State.DISCONNECTED);
+
+        boolean connectedToWifi = merlinsBeard.isConnectedToWifi();
+
+        assertThat(connectedToWifi).isFalse();
     }
 
     @Test
     public void returnFalseForIsConnectedToWifiWhenNetworkConnectionIsNotAvailable() {
         when(mockConnectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI)).thenReturn(null);
 
-        assertThat(merlinsBeard.isConnectedToWifi()).isFalse();
+        boolean connectedToWifi = merlinsBeard.isConnectedToWifi();
+
+        assertThat(connectedToWifi).isFalse();
     }
 
     @Test
@@ -82,7 +125,9 @@ public class MerlinsBeardShould {
         when(mockConnectivityManager.getNetworkInfo(ConnectivityManager.TYPE_MOBILE)).thenReturn(mockNetworkInfo);
         when(mockNetworkInfo.isConnected()).thenReturn(true);
 
-        assertThat(merlinsBeard.isConnectedToMobileNetwork()).isTrue();
+        boolean connectedToMobileNetwork = merlinsBeard.isConnectedToMobileNetwork();
+
+        assertThat(connectedToMobileNetwork).isTrue();
     }
 
     @Test
@@ -90,14 +135,28 @@ public class MerlinsBeardShould {
         when(mockConnectivityManager.getNetworkInfo(ConnectivityManager.TYPE_MOBILE)).thenReturn(mockNetworkInfo);
         when(mockNetworkInfo.isConnected()).thenReturn(false);
 
-        assertThat(merlinsBeard.isConnectedToMobileNetwork()).isFalse();
+        boolean connectedToMobileNetwork = merlinsBeard.isConnectedToMobileNetwork();
+
+        assertThat(connectedToMobileNetwork).isFalse();
     }
 
     @Test
     public void returnFalseForIsConnectedToMobileWhenNetworkConnectionIsNotAvailable() {
         when(mockConnectivityManager.getNetworkInfo(ConnectivityManager.TYPE_MOBILE)).thenReturn(null);
 
-        assertThat(merlinsBeard.isConnectedToMobileNetwork()).isFalse();
+        boolean connectedToMobileNetwork = merlinsBeard.isConnectedToMobileNetwork();
+
+        assertThat(connectedToMobileNetwork).isFalse();
+    }
+
+    private void givenWifiNetworkState(NetworkInfo.State state) {
+        Network network = Mockito.mock(Network.class);
+        NetworkInfo networkInfo = Mockito.mock(NetworkInfo.class);
+        when(networkInfo.getState()).thenReturn(state);
+        when(networkInfo.getType()).thenReturn(ConnectivityManager.TYPE_WIFI);
+        when(mockConnectivityManager.getNetworkInfo(network)).thenReturn(networkInfo);
+        when(mockAndroidVersion.isMarshmallowOrHigher()).thenReturn(true);
+        when(mockConnectivityManager.getAllNetworks()).thenReturn(new Network[]{network});
     }
 
 }

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -13,10 +13,10 @@ dependencies {
 android {
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 24
+        targetSdkVersion 25
     }
 
-    compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
 }


### PR DESCRIPTION
#### Problem
As of Android Marshmallow, `connectivityManager.getNetworkInfo(NETWORK_TYPE)` has been deprecated.

As of Android Nougat, we can no longer implicitly register to receive broadcasts for the `android.net.conn.CONNECTIVITY_CHANGE` event. This PR #88 attempted to resolve the issue but only prevents a crash and results in `CONNECTIVITY_CHANGE` events never being received on Android N and above. When a `CONNECTIVITY_CHANGE` is received it forwards it to the `MerlinService` who handles and forwards to the callbacks registered in the client activity. The `MerlinService` can be spun up in two ways, one is by explicitly binding it through merlin, the other is using the `ConnectivityReceiver`. The `ConnectivityReceiver` is disabled in Android N from implicitly starting through the manifest and must now be registered explicitly.

#### Solution
Replace `getNetworkInfo()` with a workaround that retrieves all of the active networks, checks the network info for each network and returns true or false based on whether that network is connected.

Explicitly register the receiver when creating `Merlin` so that a `MerlinService` can be started in the event that a connectivity change event is receieved.

#### Tests
We have added tests to `MerlinsBeard` to ensure we are using the correct methods based on `AndroidVersion.

#### Extra Extra
We could have used https://developer.android.com/reference/android/net/ConnectivityManager.NetworkCallback.html#onAvailable(android.net.Network) for `Android L` and above to resolve the second issue with `ConnectivityReceiver`. In reality we need to be more pragmatic in our approach. This issue needs to be fixed quickly to resolve `Android N` not working in any of our clients. I have created a ticket in the NOS tracker to ensure that this issue is addressed for the next release of this library. 

Ticket: https://novoda.atlassian.net/browse/NOS-143


#### Paired with
@jackSzm