### PR TITLE
Update lib versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ allprojects {
 buildscript {
     repositories { jcenter() }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:2.3.1'
         classpath 'com.novoda:bintray-release:0.2.4'
     }
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'bintray-release'
 
 dependencies {
-    compile 'com.android.support:support-v4:25.3.1'
+    compile 'com.android.support:support-annotations:25.3.1'
     compile 'io.reactivex:rxandroid:1.0.1'
 
     testCompile 'org.easytesting:fest-assert-core:2.0M8'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'bintray-release'
 
 dependencies {
     compile 'com.android.support:support-annotations:25.3.1'
-    compile 'io.reactivex:rxandroid:1.0.1'
+    compile 'io.reactivex:rxjava:1.0.13'
 
     testCompile 'org.easytesting:fest-assert-core:2.0M8'
     testCompile 'org.mockito:mockito-core:1.9.5'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'bintray-release'
 
 dependencies {
-    compile 'com.android.support:support-v4:24.2.1'
+    compile 'com.android.support:support-v4:25.3.1'
     compile 'io.reactivex:rxandroid:1.0.1'
 
     testCompile 'org.easytesting:fest-assert-core:2.0M8'
@@ -18,11 +18,11 @@ tasks.withType(Test) {
 android {
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 24
+        targetSdkVersion 25
     }
 
-    compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     testOptions {
         unitTests.returnDefaultValues = true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Sep 14 12:29:06 CEST 2016
+#Wed Apr 19 22:05:42 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
#### Problem
We are using very broad dependencies for what we actually need!

#### Solution
Reduce the scope of the dependencies that we are using where possible and update if necessary.

`com.android.support:support-v4:24.2.1 -> com.android.support:support-annotations:25.3.1`
 we only require the annotations in core so we can drop full support.

`io.reactivex:rxandroid:1.0.1 -> io.reactivex:rxjava:1.0.13` 
RxAndroid is not required for core, we need the corresponding `RxJava` version. We will update to latest in a future PR.

#### Credit goes to
@niltsiar
