### PR TITLE
MerlinsBeard incorrect TargetAPI 

### DIFF
--- a/core/src/main/java/com/novoda/merlin/MerlinsBeard.java
+++ b/core/src/main/java/com/novoda/merlin/MerlinsBeard.java
@@ -76,16 +76,16 @@ public class MerlinsBeard {
     }
 
     private boolean isConnectedTo(int networkType) {
-        if (androidVersion.isMarshmallowOrHigher()) {
-            return connectedToNetworkTypeForMarshmallow(networkType);
+        if (androidVersion.isLollipopOrHigher()) {
+            return connectedToNetworkTypeForLollipop(networkType);
         }
 
         NetworkInfo networkInfo = connectivityManager.getNetworkInfo(networkType);
         return networkInfo != null && networkInfo.isConnected();
     }
 
-    @TargetApi(Build.VERSION_CODES.M)
-    private boolean connectedToNetworkTypeForMarshmallow(int networkType) {
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    private boolean connectedToNetworkTypeForLollipop(int networkType) {
         Network[] networks = connectivityManager.getAllNetworks();
 
         for (Network network : networks) {

--- a/core/src/main/java/com/novoda/merlin/service/AndroidVersion.java
+++ b/core/src/main/java/com/novoda/merlin/service/AndroidVersion.java
@@ -21,4 +21,8 @@ public class AndroidVersion {
     public boolean isNougatOrHigher() {
         return deviceVersion >= Build.VERSION_CODES.N;
     }
+
+    public boolean isLollipopOrHigher() {
+        return deviceVersion >= Build.VERSION_CODES.LOLLIPOP;
+    }
 }

--- a/core/src/test/java/com/novoda/merlin/MerlinsBeardShould.java
+++ b/core/src/test/java/com/novoda/merlin/MerlinsBeardShould.java
@@ -115,9 +115,20 @@ public class MerlinsBeardShould {
     }
 
     @Test
-    public void returnFalseWhenConnectionToWifiIsNotAvailable() {
+    public void returnFalseWhenConnectionToWifiIsNotAvailableAndAndroidVersionIsBelowLollipop() {
         when(mockAndroidVersion.isLollipopOrHigher()).thenReturn(false);
         when(mockConnectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI)).thenReturn(null);
+
+        boolean connectedToWifi = merlinsBeard.isConnectedToWifi();
+
+        assertThat(connectedToWifi).isFalse();
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    @Test
+    public void returnFalseWhenConnectionToWifiIsNotAvailableAndAndroidVersionIsLollipopOrAbove() {
+        when(mockAndroidVersion.isLollipopOrHigher()).thenReturn(true);
+        when(mockConnectivityManager.getAllNetworks()).thenReturn(new Network[]{});
 
         boolean connectedToWifi = merlinsBeard.isConnectedToWifi();
 
@@ -164,6 +175,27 @@ public class MerlinsBeardShould {
         boolean connectedToMobileNetwork = merlinsBeard.isConnectedToMobileNetwork();
 
         assertThat(connectedToMobileNetwork).isFalse();
+    }
+
+    @Test
+    public void returnFalseWhenConnectionToMobileIsNotAvailableAndAndroidVersionIsBelowLollipop() {
+        when(mockAndroidVersion.isLollipopOrHigher()).thenReturn(false);
+        when(mockConnectivityManager.getNetworkInfo(ConnectivityManager.TYPE_MOBILE)).thenReturn(null);
+
+        boolean connectedToWifi = merlinsBeard.isConnectedToMobileNetwork();
+
+        assertThat(connectedToWifi).isFalse();
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    @Test
+    public void returnFalseWhenConnectionToMobileIsNotAvailableAndAndroidVersionIsLollipopOrAbove() {
+        when(mockAndroidVersion.isLollipopOrHigher()).thenReturn(true);
+        when(mockConnectivityManager.getAllNetworks()).thenReturn(new Network[]{});
+
+        boolean connectedToWifi = merlinsBeard.isConnectedToMobileNetwork();
+
+        assertThat(connectedToWifi).isFalse();
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)

--- a/core/src/test/java/com/novoda/merlin/MerlinsBeardShould.java
+++ b/core/src/test/java/com/novoda/merlin/MerlinsBeardShould.java
@@ -73,8 +73,8 @@ public class MerlinsBeardShould {
     }
 
     @Test
-    public void returnTrueWhenConnectedToWifiAndAndroidVersionIsBelowMarshmallow() {
-        when(mockAndroidVersion.isMarshmallowOrHigher()).thenReturn(false);
+    public void returnTrueWhenConnectedToWifiAndAndroidVersionIsBelowLollipop() {
+        when(mockAndroidVersion.isLollipopOrHigher()).thenReturn(false);
         when(mockConnectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI)).thenReturn(mockNetworkInfo);
         when(mockNetworkInfo.isConnected()).thenReturn(true);
 
@@ -84,8 +84,8 @@ public class MerlinsBeardShould {
     }
 
     @Test
-    public void returnFalseWhenNotConnectedToWifiAndAndroidVersionIsBelowMarshmallow() {
-        when(mockAndroidVersion.isMarshmallowOrHigher()).thenReturn(false);
+    public void returnFalseWhenNotConnectedToWifiAndAndroidVersionIsBelowLollipop() {
+        when(mockAndroidVersion.isLollipopOrHigher()).thenReturn(false);
         when(mockConnectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI)).thenReturn(mockNetworkInfo);
         when(mockNetworkInfo.isConnected()).thenReturn(false);
 
@@ -94,20 +94,20 @@ public class MerlinsBeardShould {
         assertThat(connectedToWifi).isFalse();
     }
 
-    @TargetApi(Build.VERSION_CODES.M)
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     @Test
-    public void returnTrueWhenConnectedToWifiAndAndroidVersionIsMarshmallowOrAbove() {
-        givenNetworkState(CONNECTED, ConnectivityManager.TYPE_WIFI);
+    public void returnTrueWhenConnectedToWifiAndAndroidVersionIsLollipopOrAbove() {
+        givenNetworkStateForLollipopOrAbove(CONNECTED, ConnectivityManager.TYPE_WIFI);
 
         boolean connectedToWifi = merlinsBeard.isConnectedToWifi();
 
         assertThat(connectedToWifi).isTrue();
     }
 
-    @TargetApi(Build.VERSION_CODES.M)
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     @Test
-    public void returnWhenConnectedToWifiAndAndroidVersionIsMarshmallowOrAbove() {
-        givenNetworkState(DISCONNECTED, ConnectivityManager.TYPE_WIFI);
+    public void returnFalseWhenNotConnectedToWifiAndAndroidVersionIsLollipopOrAbove() {
+        givenNetworkStateForLollipopOrAbove(DISCONNECTED, ConnectivityManager.TYPE_WIFI);
 
         boolean connectedToWifi = merlinsBeard.isConnectedToWifi();
 
@@ -115,7 +115,8 @@ public class MerlinsBeardShould {
     }
 
     @Test
-    public void returnFalseWhenConnectionIsNotAvailable() {
+    public void returnFalseWhenConnectionToWifiIsNotAvailable() {
+        when(mockAndroidVersion.isLollipopOrHigher()).thenReturn(false);
         when(mockConnectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI)).thenReturn(null);
 
         boolean connectedToWifi = merlinsBeard.isConnectedToWifi();
@@ -124,8 +125,8 @@ public class MerlinsBeardShould {
     }
 
     @Test
-    public void returnTrueWhenConnectedToMobileNetworkAndAndroidVersionIsBelowMarshmallow() {
-        when(mockAndroidVersion.isMarshmallowOrHigher()).thenReturn(false);
+    public void returnTrueWhenConnectedToMobileNetworkAndAndroidVersionIsBelowLollipop() {
+        when(mockAndroidVersion.isLollipopOrHigher()).thenReturn(false);
         when(mockConnectivityManager.getNetworkInfo(ConnectivityManager.TYPE_MOBILE)).thenReturn(mockNetworkInfo);
         when(mockNetworkInfo.isConnected()).thenReturn(true);
 
@@ -135,8 +136,8 @@ public class MerlinsBeardShould {
     }
 
     @Test
-    public void returnFalseWhenNotConnectedToMobileNetworkAndAndroidVersionIsBelowMarshmallow() {
-        when(mockAndroidVersion.isMarshmallowOrHigher()).thenReturn(false);
+    public void returnFalseWhenNotConnectedToMobileNetworkAndAndroidVersionIsBelowLollipop() {
+        when(mockAndroidVersion.isLollipopOrHigher()).thenReturn(false);
         when(mockConnectivityManager.getNetworkInfo(ConnectivityManager.TYPE_MOBILE)).thenReturn(mockNetworkInfo);
         when(mockNetworkInfo.isConnected()).thenReturn(false);
 
@@ -145,34 +146,34 @@ public class MerlinsBeardShould {
         assertThat(connectedToMobileNetwork).isFalse();
     }
 
-    @TargetApi(Build.VERSION_CODES.M)
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     @Test
-    public void returnTrueWhenConnectedToMobileNetworkAndAndroidVersionIsMarshmallowOrAbove() {
-        givenNetworkState(CONNECTED, ConnectivityManager.TYPE_MOBILE);
+    public void returnTrueWhenConnectedToMobileNetworkAndAndroidVersionIsLollipopOrAbove() {
+        givenNetworkStateForLollipopOrAbove(CONNECTED, ConnectivityManager.TYPE_MOBILE);
 
         boolean connectedToMobileNetwork = merlinsBeard.isConnectedToMobileNetwork();
 
         assertThat(connectedToMobileNetwork).isTrue();
     }
 
-    @TargetApi(Build.VERSION_CODES.M)
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     @Test
-    public void returnFalseWhenNotConnectedToMobileNetworkAndAndroidVersionIsMarshmallowOrAbove() {
-        givenNetworkState(DISCONNECTED, ConnectivityManager.TYPE_MOBILE);
+    public void returnFalseWhenNotConnectedToMobileNetworkAndAndroidVersionIsLollipopOrAbove() {
+        givenNetworkStateForLollipopOrAbove(DISCONNECTED, ConnectivityManager.TYPE_MOBILE);
 
         boolean connectedToMobileNetwork = merlinsBeard.isConnectedToMobileNetwork();
 
         assertThat(connectedToMobileNetwork).isFalse();
     }
 
-    @TargetApi(Build.VERSION_CODES.M)
-    private void givenNetworkState(boolean isConnected, int networkType) {
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    private void givenNetworkStateForLollipopOrAbove(boolean isConnected, int networkType) {
         Network network = Mockito.mock(Network.class);
         NetworkInfo networkInfo = Mockito.mock(NetworkInfo.class);
         when(networkInfo.getType()).thenReturn(networkType);
         when(networkInfo.isConnected()).thenReturn(isConnected);
         when(mockConnectivityManager.getNetworkInfo(network)).thenReturn(networkInfo);
-        when(mockAndroidVersion.isMarshmallowOrHigher()).thenReturn(true);
+        when(mockAndroidVersion.isLollipopOrHigher()).thenReturn(true);
         when(mockConnectivityManager.getAllNetworks()).thenReturn(new Network[]{network});
     }
 


### PR DESCRIPTION
#### Problem
When adding workarounds for newer versions of Android for `MerlinsBeard` the incorrect `TargetApi` was used for some methods.

#### Solution
Use the correct `TargetApi` and add a test for when no networks are returned by the system.

#### Paired with
@niltsiar did the work 😆  I'm just picking the commits and opening the PR 🎉 