### PR TITLE
Increment version for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.novoda:merlin:0.8.0'
+    compile 'com.novoda:merlin:0.10.0'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ task wrapper(type: Wrapper) {
 }
 
 allprojects {
-    version = "0.9.1"
+    version = "0.10.0"
     repositories { mavenCentral() }
 }
 


### PR DESCRIPTION
## Problem
In release v0.9 we created a workaround using `BroadcastReceiver` to tackle the deprecated `CONNECTIVITY_CHANGE` event where we explicitly register the receiver for versions pre-lollipop and post. Instead, when the `CONNECTIVITY_CHANGE` event is not supported we should make use of the "new" ConnectivityManager.NetworkCallback.

## Solution
Release `v0.10.0`  introduces the `ConnectivityManager.NetworkCallback` implementation for devices running `Lollipop` or greater. We have dropped the implicit registration of the `ConnectivityReceiver` for devices `pre-lollipop` because the `ConnectivityReceiver` would check for a `service` which didn't exist unless the service was bound and had registered a `ConnectivityReceiver` in the first place.

Templates have been added for Issues and PRs to ensure that tickets are created with the desired amount of information for the project maintainers.

Some external dependencies have been updated.

#97 Update Lib Versions
#98 MerlinsBeard incorrect TargetAPI
#99 GitHub Templates
#100 MER-096/Network Callbacks
