### PR TITLE
MER-101/Should to Test

### DIFF
--- a/core/src/test/java/com/novoda/merlin/MerlinBuilderTest.java
+++ b/core/src/test/java/com/novoda/merlin/MerlinBuilderTest.java
@@ -10,7 +10,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(JUnit4.class)
-public class MerlinBuilderShould {
+public class MerlinBuilderTest {
 
     @Test
     public void buildInstanceWithLoggingEnabled() throws Exception {

--- a/core/src/test/java/com/novoda/merlin/MerlinTest.java
+++ b/core/src/test/java/com/novoda/merlin/MerlinTest.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 @RunWith(JUnit4.class)
-public class MerlinShould {
+public class MerlinTest {
 
     @Mock
     private Context context;

--- a/core/src/test/java/com/novoda/merlin/MerlinsBeardTest.java
+++ b/core/src/test/java/com/novoda/merlin/MerlinsBeardTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 @RunWith(JUnit4.class)
-public class MerlinsBeardShould {
+public class MerlinsBeardTest {
 
     private static final boolean DISCONNECTED = false;
     private static final boolean CONNECTED = true;

--- a/core/src/test/java/com/novoda/merlin/NetworkStatusTest.java
+++ b/core/src/test/java/com/novoda/merlin/NetworkStatusTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class NetworkStatusShould {
+public class NetworkStatusTest {
 
     @Test
     public void isAvailableReturnsTrueWhenNetworkStatusNewAvailableInstanceCreated() {

--- a/core/src/test/java/com/novoda/merlin/receiver/ConnectivityCallbacksTest.java
+++ b/core/src/test/java/com/novoda/merlin/receiver/ConnectivityCallbacksTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-public class ConnectivityCallbacksShould {
+public class ConnectivityCallbacksTest {
 
     private static final boolean CONNECTED = true;
     private static final boolean DISCONNECTED = false;

--- a/core/src/test/java/com/novoda/merlin/receiver/ConnectivityChangesRegisterTest.java
+++ b/core/src/test/java/com/novoda/merlin/receiver/ConnectivityChangesRegisterTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Matchers.refEq;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-public class ConnectivityChangesRegisterShould {
+public class ConnectivityChangesRegisterTest {
 
     @Mock
     private Context context;

--- a/core/src/test/java/com/novoda/merlin/receiver/ConnectivityReceiverTest.java
+++ b/core/src/test/java/com/novoda/merlin/receiver/ConnectivityReceiverTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 @RunWith(JUnit4.class)
-public class ConnectivityReceiverShould {
+public class ConnectivityReceiverTest {
 
     private ConnectivityReceiver connectivityReceiver;
 

--- a/core/src/test/java/com/novoda/merlin/registerable/MerlinRegistererTest.java
+++ b/core/src/test/java/com/novoda/merlin/registerable/MerlinRegistererTest.java
@@ -11,7 +11,7 @@ import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 @RunWith(JUnit4.class)
-public class MerlinRegistererShould {
+public class MerlinRegistererTest {
 
     private MerlinRegisterer merlinRegisterer;
 

--- a/core/src/test/java/com/novoda/merlin/registerable/RegistererTest.java
+++ b/core/src/test/java/com/novoda/merlin/registerable/RegistererTest.java
@@ -13,7 +13,7 @@ import org.junit.runners.JUnit4;
 import static org.mockito.Mockito.*;
 
 @RunWith(JUnit4.class)
-public class RegistererShould {
+public class RegistererTest {
 
     Registerer registerer;
 

--- a/core/src/test/java/com/novoda/merlin/registerable/connection/ConnectorTest.java
+++ b/core/src/test/java/com/novoda/merlin/registerable/connection/ConnectorTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 @RunWith(JUnit4.class)
-public class ConnectorShould {
+public class ConnectorTest {
 
     private MerlinConnector<Connectable> merlinConnector;
 

--- a/core/src/test/java/com/novoda/merlin/registerable/disconnection/DisconnectorTest.java
+++ b/core/src/test/java/com/novoda/merlin/registerable/disconnection/DisconnectorTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-public class DisconnectorShould {
+public class DisconnectorTest {
 
     private MerlinConnector<Disconnectable> merlinConnector;
 

--- a/core/src/test/java/com/novoda/merlin/service/HostPingerTest.java
+++ b/core/src/test/java/com/novoda/merlin/service/HostPingerTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 @RunWith(JUnit4.class)
-public class HostPingerShould {
+public class HostPingerTest {
 
     private static final String HOST_ADDRESS = "any host address";
 

--- a/core/src/test/java/com/novoda/merlin/service/MerlinServiceTest.java
+++ b/core/src/test/java/com/novoda/merlin/service/MerlinServiceTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 @RunWith(JUnit4.class)
-public class MerlinServiceShould {
+public class MerlinServiceTest {
 
     @Mock
     private Intent intent;

--- a/core/src/test/java/com/novoda/merlin/service/NetworkStatusRetrieverTest.java
+++ b/core/src/test/java/com/novoda/merlin/service/NetworkStatusRetrieverTest.java
@@ -12,7 +12,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-public class NetworkStatusRetrieverShould {
+public class NetworkStatusRetrieverTest {
 
     @Mock
     private MerlinsBeard mockMerlinsBeards;

--- a/core/src/test/java/com/novoda/merlin/service/PingTest.java
+++ b/core/src/test/java/com/novoda/merlin/service/PingTest.java
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 @RunWith(Enclosed.class)
-public class PingShould {
+public class PingTest {
 
     private static final String HOST_ADDRESS = "any host address";
 

--- a/core/src/test/java/com/novoda/merlin/service/ResponseCodeValidatorTest.java
+++ b/core/src/test/java/com/novoda/merlin/service/ResponseCodeValidatorTest.java
@@ -13,7 +13,7 @@ import static com.novoda.merlin.service.ResponseCodeValidator.DefaultEndpointRes
 import static org.fest.assertions.api.Assertions.assertThat;
 
 @RunWith(Enclosed.class)
-public class ResponseCodeValidatorTests {
+public class ResponseCodeValidatorTest {
 
     @RunWith(Parameterized.class)
     public static class DefaultEndpointResponseCodeValidatorTest {


### PR DESCRIPTION
## Problem
The test naming in this project does not follow the convention used on many of our NOS projects.

## Solution
Rename all instances of `Should` to `Test`.

### Test(s) added
No, just updating some names.

### Screenshots
No UI changes.

### Paired with
Nobody.
