### PR TITLE
MER-102/Update version of Mockito

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     compile 'com.android.support:support-annotations:25.3.1'
 
     testCompile 'org.easytesting:fest-assert-core:2.0M8'
-    testCompile 'org.mockito:mockito-core:1.9.5'
+    testCompile 'org.mockito:mockito-core:2.7.22'
     testCompile 'junit:junit:4.12'
 }
 

--- a/core/src/test/java/com/novoda/matcher/ComponentNameMatcher.java
+++ b/core/src/test/java/com/novoda/matcher/ComponentNameMatcher.java
@@ -6,7 +6,7 @@ import org.mockito.ArgumentMatcher;
 
 import static org.mockito.Matchers.argThat;
 
-public class ComponentNameMatcher extends ArgumentMatcher<ComponentName> {
+class ComponentNameMatcher implements ArgumentMatcher<ComponentName> {
 
     private final ComponentName expected;
 
@@ -19,9 +19,7 @@ public class ComponentNameMatcher extends ArgumentMatcher<ComponentName> {
     }
 
     @Override
-    public boolean matches(Object o) {
-        ComponentName actual = (ComponentName) o;
-
-        return actual.getClassName().equals(expected.getClassName());
+    public boolean matches(ComponentName argument) {
+        return argument.getClassName().equals(expected.getClassName());
     }
 }

--- a/core/src/test/java/com/novoda/matcher/IntentMatcher.java
+++ b/core/src/test/java/com/novoda/matcher/IntentMatcher.java
@@ -6,7 +6,7 @@ import org.mockito.ArgumentMatcher;
 
 import static org.mockito.Matchers.argThat;
 
-public class IntentMatcher extends ArgumentMatcher<Intent> {
+class IntentMatcher implements ArgumentMatcher<Intent> {
 
     private final Intent expected;
 
@@ -19,9 +19,7 @@ public class IntentMatcher extends ArgumentMatcher<Intent> {
     }
 
     @Override
-    public boolean matches(Object o) {
-        Intent actual = (Intent) o;
-
-        return actual.getComponent().getClassName().equals(expected.getComponent().getClassName());
+    public boolean matches(Intent argument) {
+        return argument.getComponent().getClassName().equals(expected.getComponent().getClassName());
     }
 }

--- a/core/src/test/java/com/novoda/matcher/IntentStringExtraMatcher.java
+++ b/core/src/test/java/com/novoda/matcher/IntentStringExtraMatcher.java
@@ -6,7 +6,7 @@ import org.mockito.ArgumentMatcher;
 
 import static org.mockito.Matchers.argThat;
 
-public class IntentStringExtraMatcher extends ArgumentMatcher<Intent> {
+class IntentStringExtraMatcher implements ArgumentMatcher<Intent> {
 
     private final Intent expected;
     private final String extraKey;
@@ -21,9 +21,7 @@ public class IntentStringExtraMatcher extends ArgumentMatcher<Intent> {
     }
 
     @Override
-    public boolean matches(Object o) {
-        Intent actual = (Intent) o;
-
-        return actual.getStringExtra(extraKey).equals(expected.getStringExtra(extraKey));
+    public boolean matches(Intent argument) {
+        return argument.getStringExtra(extraKey).equals(expected.getStringExtra(extraKey));
     }
 }

--- a/core/src/test/java/com/novoda/matcher/NetworkStatusMatcher.java
+++ b/core/src/test/java/com/novoda/matcher/NetworkStatusMatcher.java
@@ -6,7 +6,7 @@ import org.mockito.ArgumentMatcher;
 
 import static org.mockito.Matchers.argThat;
 
-public class NetworkStatusMatcher extends ArgumentMatcher<NetworkStatus> {
+class NetworkStatusMatcher implements ArgumentMatcher<NetworkStatus> {
 
     private final NetworkStatus expected;
 
@@ -19,10 +19,7 @@ public class NetworkStatusMatcher extends ArgumentMatcher<NetworkStatus> {
     }
 
     @Override
-    public boolean matches(Object o) {
-        NetworkStatus actual = (NetworkStatus) o;
-
-        return actual.equals(expected);
+    public boolean matches(NetworkStatus argument) {
+        return argument.equals(expected);
     }
-
 }

--- a/merlin-rxjava/build.gradle
+++ b/merlin-rxjava/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compile 'io.reactivex:rxjava:1.2.10'
 
     testCompile 'org.easytesting:fest-assert-core:2.0M8'
-    testCompile 'org.mockito:mockito-core:1.9.5'
+    testCompile 'org.mockito:mockito-core:2.7.22'
     testCompile 'junit:junit:4.12'
 }
 

--- a/merlin-rxjava/src/test/java/com.novoda.merlin.rxjava/MerlinObservableTest.java
+++ b/merlin-rxjava/src/test/java/com.novoda.merlin.rxjava/MerlinObservableTest.java
@@ -10,7 +10,6 @@ import com.novoda.merlin.registerable.disconnection.Disconnectable;
 
 import org.junit.Before;
 import org.junit.Test;
-
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
@@ -21,7 +20,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-public class MerlinObservableShould {
+public class MerlinObservableTest {
 
     @Mock
     Merlin merlin;
@@ -33,13 +32,13 @@ public class MerlinObservableShould {
         initMocks(this);
 
         testSubscriber = MerlinObservable.from(merlin)
-                                         .test();
+                .test();
     }
 
     @Test
     public void unbindWhenUnsubscribed() {
         Subscription subscription = MerlinObservable.from(merlin)
-                                                    .subscribe();
+                .subscribe();
         subscription.unsubscribe();
 
         verify(merlin).unbind();
@@ -51,7 +50,7 @@ public class MerlinObservableShould {
 
         verify(merlin).registerConnectable(argumentCaptor.capture());
         argumentCaptor.getValue()
-                      .onConnect();
+                .onConnect();
 
         testSubscriber.assertValue(NetworkStatus.newAvailableInstance());
     }
@@ -62,7 +61,7 @@ public class MerlinObservableShould {
 
         verify(merlin).registerDisconnectable(argumentCaptor.capture());
         argumentCaptor.getValue()
-                      .onDisconnect();
+                .onDisconnect();
 
         testSubscriber.assertValue(NetworkStatus.newUnavailableInstance());
     }
@@ -73,7 +72,7 @@ public class MerlinObservableShould {
 
         verify(merlin).registerBindable(argumentCaptor.capture());
         argumentCaptor.getValue()
-                      .onBind(NetworkStatus.newAvailableInstance());
+                .onBind(NetworkStatus.newAvailableInstance());
 
         testSubscriber.assertValue(NetworkStatus.newAvailableInstance());
     }
@@ -84,7 +83,7 @@ public class MerlinObservableShould {
 
         verify(merlin).registerBindable(argumentCaptor.capture());
         argumentCaptor.getValue()
-                      .onBind(NetworkStatus.newUnavailableInstance());
+                .onBind(NetworkStatus.newUnavailableInstance());
 
         testSubscriber.assertValue(NetworkStatus.newUnavailableInstance());
     }

--- a/merlin-rxjava2/build.gradle
+++ b/merlin-rxjava2/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compile 'io.reactivex.rxjava2:rxjava:2.0.9'
 
     testCompile 'org.easytesting:fest-assert-core:2.0M8'
-    testCompile 'org.mockito:mockito-core:1.9.5'
+    testCompile 'org.mockito:mockito-core:2.7.22'
     testCompile 'junit:junit:4.12'
 }
 

--- a/merlin-rxjava2/src/test/java/com/novoda/merlin/rxjava2/MerlinFlowableTest.java
+++ b/merlin-rxjava2/src/test/java/com/novoda/merlin/rxjava2/MerlinFlowableTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-public class MerlinFlowableShould {
+public class MerlinFlowableTest {
 
     @Mock
     Merlin merlin;


### PR DESCRIPTION
## Problem
As per issue #102 we are using an outdated version of `Mockito`. 

## Solution
Add latest supported version of `Mockito` and ensure that tests still pass. See **Follow-up work** for next steps.

### Test(s) added
No, just updates existing.

### Screenshots
No UI changes.

### Paired with
Nobody.

### Follow-up work
- Use BDD in test names
- Use BDD imports for Mockito
- Remove unnecessary `@RunWith(JUnit4.class)`
- Add additional tests for `Merlin`
