### PR TITLE
Remove unused checks for test files.

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -9,11 +9,6 @@ dependencies {
     testCompile 'junit:junit:4.12'
 }
 
-tasks.withType(Test) {
-    scanForTestClasses = false
-    include "**/*Should.class"
-}
-
 android {
     defaultConfig {
         minSdkVersion 14

--- a/merlin-rxjava/build.gradle
+++ b/merlin-rxjava/build.gradle
@@ -11,11 +11,6 @@ dependencies {
     testCompile 'junit:junit:4.12'
 }
 
-tasks.withType(Test) {
-    scanForTestClasses = false
-    include "**/*Should.class"
-}
-
 android {
     defaultConfig {
         minSdkVersion 14

--- a/merlin-rxjava2/build.gradle
+++ b/merlin-rxjava2/build.gradle
@@ -11,11 +11,6 @@ dependencies {
     testCompile 'junit:junit:4.12'
 }
 
-tasks.withType(Test) {
-    scanForTestClasses = false
-    include "**/*Should.class"
-}
-
 android {
     defaultConfig {
         minSdkVersion 14


### PR DESCRIPTION
## Problem
The ci is not recognising test classes 😟  the gradle script ignores test classes in favour of the `Should` naming scheme.

## Solution
Remove the `Should` naming scheme from gradle and allow it to look for default test classes.

### Test(s) added
No, just fixing the project configuration.

### Screenshots
No UI changes.

### Paired with
Nobody
