### PR TITLE
MER-101/BDD naming for tests

### DIFF
--- a/core/src/main/java/com/novoda/merlin/MerlinBuilder.java
+++ b/core/src/main/java/com/novoda/merlin/MerlinBuilder.java
@@ -6,7 +6,7 @@ import com.novoda.merlin.registerable.MerlinRegisterer;
 import com.novoda.merlin.registerable.Registerer;
 import com.novoda.merlin.registerable.bind.BindListener;
 import com.novoda.merlin.registerable.bind.Bindable;
-import com.novoda.merlin.registerable.bind.OnBinder;
+import com.novoda.merlin.registerable.bind.Binder;
 import com.novoda.merlin.registerable.connection.ConnectListener;
 import com.novoda.merlin.registerable.connection.Connectable;
 import com.novoda.merlin.registerable.connection.Connector;
@@ -63,7 +63,7 @@ public class MerlinBuilder {
      */
     public MerlinBuilder withBindableCallbacks() {
         bindableRegisterer = new MerlinRegisterer<>();
-        this.merlinOnBinder = new OnBinder(bindableRegisterer);
+        this.merlinOnBinder = new Binder(bindableRegisterer);
         return this;
     }
 

--- a/core/src/main/java/com/novoda/merlin/registerable/MerlinRegisterer.java
+++ b/core/src/main/java/com/novoda/merlin/registerable/MerlinRegisterer.java
@@ -8,7 +8,7 @@ public class MerlinRegisterer<T extends Registerable> implements MerlinConnector
     private final List<WeakRegisterableReference<T>> registerableList;
 
     public MerlinRegisterer() {
-        registerableList = new ArrayList<WeakRegisterableReference<T>>();
+        registerableList = new ArrayList<>();
     }
 
     @Override

--- a/core/src/main/java/com/novoda/merlin/registerable/bind/Binder.java
+++ b/core/src/main/java/com/novoda/merlin/registerable/bind/Binder.java
@@ -5,9 +5,9 @@ import com.novoda.merlin.NetworkStatus;
 import com.novoda.merlin.registerable.MerlinCallbackManager;
 import com.novoda.merlin.registerable.MerlinConnector;
 
-public class OnBinder extends MerlinCallbackManager<Bindable> implements BindListener {
+public class Binder extends MerlinCallbackManager<Bindable> implements BindListener {
 
-    public OnBinder(MerlinConnector<Bindable> merlinConnector) {
+    public Binder(MerlinConnector<Bindable> merlinConnector) {
         super(merlinConnector);
     }
 

--- a/core/src/main/java/com/novoda/merlin/service/HostPinger.java
+++ b/core/src/main/java/com/novoda/merlin/service/HostPinger.java
@@ -20,13 +20,13 @@ class HostPinger {
 
     }
 
-    public static HostPinger withDefaultEndpointValidation(PingerCallback pingerCallback) {
+    static HostPinger withDefaultEndpointValidation(PingerCallback pingerCallback) {
         MerlinLog.d("Host address not set, using Merlin default: " + Merlin.DEFAULT_ENDPOINT);
         PingTaskFactory pingTaskFactory = new PingTaskFactory(pingerCallback, new ResponseCodeFetcher(), new DefaultEndpointResponseCodeValidator());
         return new HostPinger(pingerCallback, Merlin.DEFAULT_ENDPOINT, pingTaskFactory);
     }
 
-    public static HostPinger withCustomEndpointAndValidation(PingerCallback pingerCallback, String hostAddress, ResponseCodeValidator validator) {
+    static HostPinger withCustomEndpointAndValidation(PingerCallback pingerCallback, String hostAddress, ResponseCodeValidator validator) {
         PingTaskFactory pingTaskFactory = new PingTaskFactory(pingerCallback, new ResponseCodeFetcher(), validator);
         return new HostPinger(pingerCallback, hostAddress, pingTaskFactory);
     }
@@ -37,16 +37,16 @@ class HostPinger {
         this.pingTaskFactory = pingTaskFactory;
     }
 
-    public void ping() {
+    void ping() {
         PingTask pingTask = pingTaskFactory.create(hostAddress);
         pingTask.execute();
     }
 
-    public void noNetworkToPing() {
+    void noNetworkToPing() {
         pingerCallback.onFailure();
     }
 
-    public static class ResponseCodeFetcher {
+    static class ResponseCodeFetcher {
 
         public int from(String endpoint) {
             return MerlinRequest.head(endpoint).getResponseCode();

--- a/core/src/test/java/com/novoda/merlin/MerlinBuilderTest.java
+++ b/core/src/test/java/com/novoda/merlin/MerlinBuilderTest.java
@@ -3,13 +3,10 @@ package com.novoda.merlin;
 import android.test.mock.MockApplication;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(JUnit4.class)
 public class MerlinBuilderTest {
 
     @Test

--- a/core/src/test/java/com/novoda/merlin/MerlinBuilderTest.java
+++ b/core/src/test/java/com/novoda/merlin/MerlinBuilderTest.java
@@ -1,28 +1,38 @@
 package com.novoda.merlin;
 
-import android.test.mock.MockApplication;
+import android.content.Context;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class MerlinBuilderTest {
 
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private Context context;
+
     @Test
-    public void buildInstanceWithLoggingEnabled() throws Exception {
-        Merlin merlin = new MerlinBuilder()
+    public void whenBuildingMerlinInstanceWithLogging_thenLogsWithMerlinLog() {
+        new MerlinBuilder()
                 .withLogging(true)
-                .build(new MockApplication());
+                .build(context);
 
         assertTrue(MerlinLog.LOGGING);
     }
 
     @Test
-    public void buildInstanceWithLoggingDisabled() throws Exception {
-        Merlin merlin = new MerlinBuilder()
+    public void whenBuildingMerlinInstanceWithoutLogging_thenDoesNotLogWithMerlinLog() throws Exception {
+        new MerlinBuilder()
                 .withLogging(false)
-                .build(new MockApplication());
+                .build(context);
 
         assertFalse(MerlinLog.LOGGING);
     }

--- a/core/src/test/java/com/novoda/merlin/MerlinBuilderTest.java
+++ b/core/src/test/java/com/novoda/merlin/MerlinBuilderTest.java
@@ -8,8 +8,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.fest.assertions.api.Assertions.assertThat;
 
 public class MerlinBuilderTest {
 
@@ -25,7 +24,7 @@ public class MerlinBuilderTest {
                 .withLogging(true)
                 .build(context);
 
-        assertTrue(MerlinLog.LOGGING);
+        assertThat(MerlinLog.LOGGING).isTrue();
     }
 
     @Test
@@ -34,7 +33,7 @@ public class MerlinBuilderTest {
                 .withLogging(false)
                 .build(context);
 
-        assertFalse(MerlinLog.LOGGING);
+        assertThat(MerlinLog.LOGGING).isFalse();
     }
 
 }

--- a/core/src/test/java/com/novoda/merlin/MerlinTest.java
+++ b/core/src/test/java/com/novoda/merlin/MerlinTest.java
@@ -7,14 +7,11 @@ import com.novoda.merlin.service.ResponseCodeValidator;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-@RunWith(JUnit4.class)
 public class MerlinTest {
 
     @Mock

--- a/core/src/test/java/com/novoda/merlin/MerlinTest.java
+++ b/core/src/test/java/com/novoda/merlin/MerlinTest.java
@@ -29,7 +29,7 @@ public class MerlinTest {
     @Mock
     private MerlinServiceBinder serviceBinder;
     @Mock
-    private ResponseCodeValidator mockValidator;
+    private ResponseCodeValidator validator;
     @Mock
     private Registerer registerer;
 
@@ -44,10 +44,10 @@ public class MerlinTest {
     public void whenBindingWithACustomEndpoint_thenSetsEndPoint() {
         String hostname = "startTheMerlinServiceWithAHostnameWhenProvided";
 
-        merlin.setEndpoint(hostname, mockValidator);
+        merlin.setEndpoint(hostname, validator);
         merlin.bind();
 
-        verify(serviceBinder).setEndpoint(hostname, mockValidator);
+        verify(serviceBinder).setEndpoint(hostname, validator);
     }
 
     @Test

--- a/core/src/test/java/com/novoda/merlin/MerlinTest.java
+++ b/core/src/test/java/com/novoda/merlin/MerlinTest.java
@@ -2,42 +2,46 @@ package com.novoda.merlin;
 
 import android.content.Context;
 
+import com.novoda.merlin.registerable.Registerer;
+import com.novoda.merlin.registerable.bind.Bindable;
+import com.novoda.merlin.registerable.connection.Connectable;
+import com.novoda.merlin.registerable.disconnection.Disconnectable;
 import com.novoda.merlin.service.MerlinServiceBinder;
 import com.novoda.merlin.service.ResponseCodeValidator;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 public class MerlinTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Mock
     private Context context;
     @Mock
     private MerlinServiceBinder serviceBinder;
     @Mock
-    ResponseCodeValidator mockValidator;
+    private ResponseCodeValidator mockValidator;
+    @Mock
+    private Registerer registerer;
 
     private Merlin merlin;
 
     @Before
-    public void setUp() throws Exception {
-        initMocks(this);
-        merlin = new Merlin(serviceBinder, null);
+    public void setUp() {
+        merlin = new Merlin(serviceBinder, registerer);
     }
 
     @Test
-    public void startTheMerlinService() throws Exception {
-        merlin.bind();
-
-        verify(serviceBinder).bindService();
-    }
-
-    @Test
-    public void bindTheMerlinServiceWithAHostnameWhenProvided() throws Exception {
+    public void whenBindingWithACustomEndpoint_thenSetsEndPoint() {
         String hostname = "startTheMerlinServiceWithAHostnameWhenProvided";
 
         merlin.setEndpoint(hostname, mockValidator);
@@ -47,10 +51,44 @@ public class MerlinTest {
     }
 
     @Test
-    public void unbindTheMerlinService() throws Exception {
+    public void whenBinding_thenBindsService() {
+        merlin.bind();
+
+        verify(serviceBinder).bindService();
+    }
+
+    @Test
+    public void whenUnbinding_thenUnbindsService() {
         merlin.unbind();
 
         verify(serviceBinder).unbind();
+    }
+
+    @Test
+    public void whenRegisteringConnectable_thenRegistersConnectable() {
+        Connectable connectable = mock(Connectable.class);
+
+        merlin.registerConnectable(connectable);
+
+        verify(registerer).registerConnectable(connectable);
+    }
+
+    @Test
+    public void whenRegisteringDisconnectable_thenRegistersDisconnectable() {
+        Disconnectable disconnectable = mock(Disconnectable.class);
+
+        merlin.registerDisconnectable(disconnectable);
+
+        verify(registerer).registerDisconnectable(disconnectable);
+    }
+
+    @Test
+    public void whenRegisteringBindable_thenRegistersBindable() {
+        Bindable bindable = mock(Bindable.class);
+
+        merlin.registerBindable(bindable);
+
+        verify(registerer).registerBindable(bindable);
     }
 
 }

--- a/core/src/test/java/com/novoda/merlin/MerlinsBeardTest.java
+++ b/core/src/test/java/com/novoda/merlin/MerlinsBeardTest.java
@@ -10,8 +10,6 @@ import com.novoda.merlin.service.AndroidVersion;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
@@ -19,7 +17,6 @@ import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-@RunWith(JUnit4.class)
 public class MerlinsBeardTest {
 
     private static final boolean DISCONNECTED = false;

--- a/core/src/test/java/com/novoda/merlin/NetworkStatusTest.java
+++ b/core/src/test/java/com/novoda/merlin/NetworkStatusTest.java
@@ -2,23 +2,22 @@ package com.novoda.merlin;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.fest.assertions.api.Assertions.assertThat;
 
 public class NetworkStatusTest {
 
     @Test
-    public void isAvailableReturnsTrueWhenNetworkStatusNewAvailableInstanceCreated() {
+    public void givenNewAvailableInstance_whenCheckingIsAvailable_thenReturnsTrue() {
         NetworkStatus networkStatus = NetworkStatus.newAvailableInstance();
 
-        assertTrue(networkStatus.isAvailable());
+        assertThat(networkStatus.isAvailable()).isTrue();
     }
 
     @Test
-    public void isAvailableReturnsFalseWhenNetworkStatusNewUnavailableInstanceCreated() {
+    public void givenNewUnavailableInstance_whenCheckingIsAvailable_thenReturnsFalse() {
         NetworkStatus networkStatus = NetworkStatus.newUnavailableInstance();
 
-        assertFalse(networkStatus.isAvailable());
+        assertThat(networkStatus.isAvailable()).isFalse();
     }
 
 }

--- a/core/src/test/java/com/novoda/merlin/receiver/ConnectivityCallbacksTest.java
+++ b/core/src/test/java/com/novoda/merlin/receiver/ConnectivityCallbacksTest.java
@@ -9,15 +9,16 @@ import android.os.Build;
 import com.novoda.merlin.service.MerlinService;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
 
-@TargetApi(Build.VERSION_CODES.LOLLIPOP)
 public class ConnectivityCallbacksTest {
 
     private static final boolean CONNECTED = true;
@@ -27,6 +28,11 @@ public class ConnectivityCallbacksTest {
     private static final String ANY_EXTRA_INFO = "extra info";
 
     private static final int MAX_MS_TO_LIVE = 0;
+
+    private static final Network MISSING_NETWORK = null;
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Mock
     private ConnectivityManager connectivityManager;
@@ -39,37 +45,58 @@ public class ConnectivityCallbacksTest {
 
     @Before
     public void setUp() {
-        initMocks(this);
         networkCallbacks = new ConnectivityCallbacks(connectivityManager, merlinService);
     }
 
     @Test
-    public void notifyMerlinServiceOfAvailableNetwork() {
-        NetworkInfo networkInfo = givenNetworkInfoWith(CONNECTED, ANY_REASON, ANY_EXTRA_INFO);
+    public void givenConnectedNetworkInfo_whenNetworkIsAvailable_thenNotifiesMerlinServiceOfConnectedNetwork() {
+        NetworkInfo connectedNetworkInfo = givenNetworkInfoWith(CONNECTED, ANY_REASON, ANY_EXTRA_INFO);
 
         networkCallbacks.onAvailable(network);
 
-        thenConnectivityChangeEventContains(networkInfo);
+        thenNotifiesMerlinServiceOf(connectedNetworkInfo);
     }
 
     @Test
-    public void notifyMerlinServiceOfLosingNetwork() {
-        NetworkInfo networkInfo = givenNetworkInfoWith(DISCONNECTED, ANY_REASON, ANY_EXTRA_INFO);
+    public void givenDisconnectedNetworkInfo_whenLosingNetwork_thenNotifiesMerlinServiceOfDisconnectedNetwork() {
+        NetworkInfo disconnectedNetworkInfo = givenNetworkInfoWith(DISCONNECTED, ANY_REASON, ANY_EXTRA_INFO);
 
         networkCallbacks.onLosing(network, MAX_MS_TO_LIVE);
 
-        thenConnectivityChangeEventContains(networkInfo);
+        thenNotifiesMerlinServiceOf(disconnectedNetworkInfo);
     }
 
     @Test
-    public void notifyMerlinServiceOfLostNetwork() {
-        NetworkInfo networkInfo = givenNetworkInfoWith(DISCONNECTED, ANY_REASON, ANY_EXTRA_INFO);
+    public void givenDisconnectedNetworkInfo_whenNetworkIsLost_thenNotifiesMerlinServiceOfLostNetwork() {
+        NetworkInfo disconnectedNetworkInfo = givenNetworkInfoWith(DISCONNECTED, ANY_REASON, ANY_EXTRA_INFO);
 
         networkCallbacks.onLost(network);
 
-        thenConnectivityChangeEventContains(networkInfo);
+        thenNotifiesMerlinServiceOf(disconnectedNetworkInfo);
     }
 
+    @Test
+    public void givenMissingNetwork_whenNetworkIsAvailable_thenNotifiesMerlinServiceOfMissingNetwork() {
+        networkCallbacks.onAvailable(MISSING_NETWORK);
+
+        thenNotifiesMerlinServiceOfMissingNetwork();
+    }
+
+    @Test
+    public void givenMissingNetwork_whenLosingNetwork_thenNotifiesMerlinServiceOfMissingNetwork() {
+        networkCallbacks.onLosing(MISSING_NETWORK, MAX_MS_TO_LIVE);
+
+        thenNotifiesMerlinServiceOfMissingNetwork();
+    }
+
+    @Test
+    public void givenMissingNetwork_whenNetworkIsLost_thenNotifiesMerlinServiceOfMissingNetwork() {
+        networkCallbacks.onLost(MISSING_NETWORK);
+
+        thenNotifiesMerlinServiceOfMissingNetwork();
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     private NetworkInfo givenNetworkInfoWith(boolean connected, String reason, String extraInfo) {
         NetworkInfo networkInfo = mock(NetworkInfo.class);
 
@@ -81,7 +108,7 @@ public class ConnectivityCallbacksTest {
         return networkInfo;
     }
 
-    private void thenConnectivityChangeEventContains(NetworkInfo networkInfo) {
+    private void thenNotifiesMerlinServiceOf(NetworkInfo networkInfo) {
         ArgumentCaptor<ConnectivityChangeEvent> argumentCaptor = ArgumentCaptor.forClass(ConnectivityChangeEvent.class);
         verify(merlinService).onConnectivityChanged(argumentCaptor.capture());
         assertThat(argumentCaptor.getValue()).isEqualTo(ConnectivityChangeEvent.createWithNetworkInfoChangeEvent(
@@ -89,6 +116,12 @@ public class ConnectivityCallbacksTest {
                 networkInfo.getExtraInfo(),
                 networkInfo.getReason()
         ));
+    }
+
+    private void thenNotifiesMerlinServiceOfMissingNetwork() {
+        ArgumentCaptor<ConnectivityChangeEvent> argumentCaptor = ArgumentCaptor.forClass(ConnectivityChangeEvent.class);
+        verify(merlinService).onConnectivityChanged(argumentCaptor.capture());
+        assertThat(argumentCaptor.getValue()).isEqualTo(ConnectivityChangeEvent.createWithoutConnection());
     }
 
 }

--- a/core/src/test/java/com/novoda/merlin/receiver/ConnectivityCallbacksTest.java
+++ b/core/src/test/java/com/novoda/merlin/receiver/ConnectivityCallbacksTest.java
@@ -17,7 +17,9 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import static org.fest.assertions.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class ConnectivityCallbacksTest {
 
@@ -100,10 +102,10 @@ public class ConnectivityCallbacksTest {
     private NetworkInfo givenNetworkInfoWith(boolean connected, String reason, String extraInfo) {
         NetworkInfo networkInfo = mock(NetworkInfo.class);
 
-        when(networkInfo.isConnected()).thenReturn(connected);
-        when(networkInfo.getReason()).thenReturn(reason);
-        when(networkInfo.getExtraInfo()).thenReturn(extraInfo);
-        when(connectivityManager.getNetworkInfo(network)).thenReturn(networkInfo);
+        given(networkInfo.isConnected()).willReturn(connected);
+        given(networkInfo.getReason()).willReturn(reason);
+        given(networkInfo.getExtraInfo()).willReturn(extraInfo);
+        given(connectivityManager.getNetworkInfo(network)).willReturn(networkInfo);
 
         return networkInfo;
     }

--- a/core/src/test/java/com/novoda/merlin/receiver/ConnectivityChangesRegisterTest.java
+++ b/core/src/test/java/com/novoda/merlin/receiver/ConnectivityChangesRegisterTest.java
@@ -11,16 +11,21 @@ import com.novoda.merlin.service.AndroidVersion;
 import com.novoda.merlin.service.MerlinService;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.refEq;
 import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 public class ConnectivityChangesRegisterTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Mock
     private Context context;
@@ -35,13 +40,11 @@ public class ConnectivityChangesRegisterTest {
 
     @Before
     public void setUp() {
-        initMocks(this);
-
         connectivityChangesRegister = new ConnectivityChangesRegister(context, connectivityManager, androidVersion, merlinService);
     }
 
     @Test
-    public void givenRegisteredBroadcastReceiver_whenBindingForASecondTime_thenOriginalBroadcastReceieverIsRegisteredAgain() {
+    public void givenRegisteredBroadcastReceiver_whenBindingForASecondTime_thenOriginalBroadcastReceiverIsRegisteredAgain() {
         ArgumentCaptor<ConnectivityReceiver> broadcastReceiver = givenRegisteredBroadcastReceiver();
 
         connectivityChangesRegister.register();

--- a/core/src/test/java/com/novoda/merlin/receiver/ConnectivityChangesRegisterTest.java
+++ b/core/src/test/java/com/novoda/merlin/receiver/ConnectivityChangesRegisterTest.java
@@ -18,9 +18,11 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.refEq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class ConnectivityChangesRegisterTest {
 
@@ -82,7 +84,7 @@ public class ConnectivityChangesRegisterTest {
     }
 
     private ArgumentCaptor<ConnectivityReceiver> givenRegisteredBroadcastReceiver() {
-        when(androidVersion.isLollipopOrHigher()).thenReturn(false);
+        given(androidVersion.isLollipopOrHigher()).willReturn(false);
         connectivityChangesRegister.register();
         ArgumentCaptor<ConnectivityReceiver> argumentCaptor = ArgumentCaptor.forClass(ConnectivityReceiver.class);
         verify(context).registerReceiver(argumentCaptor.capture(), refEq(new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION)));
@@ -91,7 +93,7 @@ public class ConnectivityChangesRegisterTest {
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     private ArgumentCaptor<ConnectivityCallbacks> givenRegisteredMerlinNetworkCallbacks() {
-        when(androidVersion.isLollipopOrHigher()).thenReturn(true);
+        given(androidVersion.isLollipopOrHigher()).willReturn(true);
         connectivityChangesRegister.register();
         ArgumentCaptor<ConnectivityCallbacks> argumentCaptor = ArgumentCaptor.forClass(ConnectivityCallbacks.class);
         verify(connectivityManager).registerNetworkCallback(refEq((new NetworkRequest.Builder()).build()), argumentCaptor.capture());

--- a/core/src/test/java/com/novoda/merlin/receiver/ConnectivityReceiverTest.java
+++ b/core/src/test/java/com/novoda/merlin/receiver/ConnectivityReceiverTest.java
@@ -44,7 +44,7 @@ public class ConnectivityReceiverTest {
             @Override
             protected MerlinsBeard getMerlinsBeard(Context context) {
                 MerlinsBeard mockMerlinsBeard = mock(MerlinsBeard.class);
-                when(mockMerlinsBeard.isConnected()).thenReturn(true);
+                given(mockMerlinsBeard.isConnected()).willReturn(true);
                 return mockMerlinsBeard;
             }
         };

--- a/core/src/test/java/com/novoda/merlin/receiver/ConnectivityReceiverTest.java
+++ b/core/src/test/java/com/novoda/merlin/receiver/ConnectivityReceiverTest.java
@@ -11,8 +11,6 @@ import com.novoda.merlin.service.MerlinService;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -20,7 +18,6 @@ import org.mockito.junit.MockitoRule;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
-@RunWith(JUnit4.class)
 public class ConnectivityReceiverTest {
 
     @Rule

--- a/core/src/test/java/com/novoda/merlin/receiver/ConnectivityReceiverTest.java
+++ b/core/src/test/java/com/novoda/merlin/receiver/ConnectivityReceiverTest.java
@@ -34,6 +34,7 @@ public class ConnectivityReceiverTest {
     @Before
     public void setUp() throws Exception {
         context = new MockContext();
+        // TODO: See https://github.com/novoda/merlin/issues/111
         connectivityReceiver = new ConnectivityReceiver() {
             @Override
             protected MerlinService getMerlinService(Context context) {

--- a/core/src/test/java/com/novoda/merlin/receiver/ConnectivityReceiverTest.java
+++ b/core/src/test/java/com/novoda/merlin/receiver/ConnectivityReceiverTest.java
@@ -43,9 +43,9 @@ public class ConnectivityReceiverTest {
 
             @Override
             protected MerlinsBeard getMerlinsBeard(Context context) {
-                MerlinsBeard mockMerlinsBeard = mock(MerlinsBeard.class);
-                given(mockMerlinsBeard.isConnected()).willReturn(true);
-                return mockMerlinsBeard;
+                MerlinsBeard merlinsBeard = mock(MerlinsBeard.class);
+                given(merlinsBeard.isConnected()).willReturn(true);
+                return merlinsBeard;
             }
         };
     }

--- a/core/src/test/java/com/novoda/merlin/receiver/ConnectivityReceiverTest.java
+++ b/core/src/test/java/com/novoda/merlin/receiver/ConnectivityReceiverTest.java
@@ -9,27 +9,34 @@ import com.novoda.merlin.MerlinsBeard;
 import com.novoda.merlin.service.MerlinService;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 @RunWith(JUnit4.class)
 public class ConnectivityReceiverTest {
 
-    private ConnectivityReceiver connectivityReceiver;
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
 
-    Context context;
     @Mock
-    MerlinService merlinService;
+    private Intent intent;
+    @Mock
+    private MerlinService merlinService;
+
+    private Context context;
+    private ConnectivityReceiver connectivityReceiver;
 
     @Before
     public void setUp() throws Exception {
         context = new MockContext();
-        initMocks(this);
         connectivityReceiver = new ConnectivityReceiver() {
             @Override
             protected MerlinService getMerlinService(Context context) {
@@ -46,36 +53,33 @@ public class ConnectivityReceiverTest {
     }
 
     @Test
-    public void notNotifyTheMerlinServiceOnNullIntents() throws Exception {
+    public void givenNullIntent_whenReceivingAnIntent_thenDoesNotNotifyMerlinService() {
         connectivityReceiver.onReceive(context, null);
 
         verifyZeroInteractions(merlinService);
     }
 
     @Test
-    public void notNotifyTheMerlinServiceOnNonConnectivityIntents() throws Exception {
-        Intent mockIntent = mock(Intent.class);
-        when(mockIntent.getAction()).thenReturn("notNotifyTheMerlinServiceOnNonConnectivityIntents");
+    public void givenNoConnectivityIntents_whenReceivingAnIntent_thenDoesNotNotifyMerlinService() {
+        given(intent.getAction()).willReturn("notNotifyTheMerlinServiceOnNonConnectivityIntents");
 
-        connectivityReceiver.onReceive(context, mockIntent);
+        connectivityReceiver.onReceive(context, intent);
 
         verifyZeroInteractions(merlinService);
     }
 
     @Test
-    public void notifyTheMerlinServiceOnValidConnectivityIntents() throws Exception {
-        Intent mockIntent = mock(Intent.class);
-        when(mockIntent.getAction()).thenReturn(ConnectivityManager.CONNECTIVITY_ACTION);
+    public void givenValidConnectivityIntent_whenReceivingAnIntent_thenNotifiesMerlinService() {
+        given(intent.getAction()).willReturn(ConnectivityManager.CONNECTIVITY_ACTION);
 
-        connectivityReceiver.onReceive(context, mockIntent);
+        connectivityReceiver.onReceive(context, intent);
 
         verify(merlinService).onConnectivityChanged(any(ConnectivityChangeEvent.class));
     }
 
     @Test
-    public void notExplodeWhenTheMerlinServiceIsNull() throws Exception {
-        Intent intent = new Intent();
-        intent.setAction(ConnectivityManager.CONNECTIVITY_ACTION);
+    public void givenNullMerlinService_whenReceivingAnIntent_thenDoesNotThrowAnException() {
+        given(intent.getAction()).willReturn(ConnectivityManager.CONNECTIVITY_ACTION);
         merlinService = null;
 
         connectivityReceiver.onReceive(context, intent);

--- a/core/src/test/java/com/novoda/merlin/registerable/MerlinRegistererTest.java
+++ b/core/src/test/java/com/novoda/merlin/registerable/MerlinRegistererTest.java
@@ -13,12 +13,12 @@ public class MerlinRegistererTest {
     private MerlinRegisterer merlinRegisterer;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         merlinRegisterer = new MerlinRegisterer();
     }
 
     @Test
-    public void registerRegisterables() throws Exception {
+    public void givenRegisterable_whenRegistering_thenAddsRegisterableToList() {
         Registerable registerable = mock(Registerable.class);
 
         merlinRegisterer.register(registerable);
@@ -27,10 +27,8 @@ public class MerlinRegistererTest {
     }
 
     @Test
-    public void notHoldReferences() throws Exception {
-        Registerable registerable = mock(Registerable.class);
-
-        merlinRegisterer.register(registerable);
+    public void givenRegisteredRegisterable_whenSystemPerformsGc_thenDoesNotHoldRegisterableReference() {
+        Registerable registerable = givenRegisteredRegisterable();
 
         registerable = null;
         System.gc();
@@ -39,7 +37,7 @@ public class MerlinRegistererTest {
     }
 
     @Test
-    public void notRegisterTheSameObjectMoreThanOnce() throws Exception {
+    public void givenConnectableRegisterable_whenRegisteringMultipleTimes_thenDoesNotRegisterTheSameObjectMoreThanOnce() {
         Connectable connectable = mock(Connectable.class);
 
         merlinRegisterer.register(connectable);
@@ -47,6 +45,12 @@ public class MerlinRegistererTest {
         merlinRegisterer.register(connectable);
 
         assertThat(merlinRegisterer.get()).hasSize(1);
+    }
+
+    private Registerable givenRegisteredRegisterable() {
+        Registerable registerable = mock(Registerable.class);
+        merlinRegisterer.register(registerable);
+        return registerable;
     }
 
 }

--- a/core/src/test/java/com/novoda/merlin/registerable/MerlinRegistererTest.java
+++ b/core/src/test/java/com/novoda/merlin/registerable/MerlinRegistererTest.java
@@ -4,13 +4,10 @@ import com.novoda.merlin.registerable.connection.Connectable;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-@RunWith(JUnit4.class)
 public class MerlinRegistererTest {
 
     private MerlinRegisterer merlinRegisterer;

--- a/core/src/test/java/com/novoda/merlin/registerable/RegistererTest.java
+++ b/core/src/test/java/com/novoda/merlin/registerable/RegistererTest.java
@@ -7,12 +7,9 @@ import com.novoda.merlin.registerable.connection.Connectable;
 import com.novoda.merlin.registerable.disconnection.Disconnectable;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 import static org.mockito.Mockito.*;
 
-@RunWith(JUnit4.class)
 public class RegistererTest {
 
     Registerer registerer;

--- a/core/src/test/java/com/novoda/merlin/registerable/RegistererTest.java
+++ b/core/src/test/java/com/novoda/merlin/registerable/RegistererTest.java
@@ -1,110 +1,102 @@
 package com.novoda.merlin.registerable;
 
 import com.novoda.merlin.MerlinException;
-import com.novoda.merlin.NetworkStatus;
 import com.novoda.merlin.registerable.bind.Bindable;
 import com.novoda.merlin.registerable.connection.Connectable;
 import com.novoda.merlin.registerable.disconnection.Disconnectable;
 
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 import static org.mockito.Mockito.*;
 
 public class RegistererTest {
 
-    Registerer registerer;
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private MerlinConnector<Connectable> connector;
+    @Mock
+    private MerlinConnector<Disconnectable> disconnector;
+    @Mock
+    private MerlinConnector<Bindable> binder;
+
+    private Registerer registerer;
+
+    @Before
+    public void setUp() {
+        registerer = new Registerer(connector, disconnector, binder);
+    }
 
     @Test(expected = MerlinException.class)
-    public void throwADeveloperExceptionWhenAConnectorIsNotSetButRegisterConnectableIsCalled() throws Exception {
+    public void givenMissingConnector_whenRegisteringConnectable_thenThrowsDeveloperException() {
         registerer = new Registerer(null, null, null);
-        Connectable connectable = mock(Connectable.class);
 
+        Connectable connectable = mock(Connectable.class);
         registerer.registerConnectable(connectable);
     }
 
     @Test(expected = MerlinException.class)
-    public void throwADeveloperExceptionWhenADisconnectorIsNotSetButRegisterDisconnectableIsCalled() throws Exception {
+    public void givenMissingDisconnector_thenRegisteringDisconnectable_thenThrowsDeveloperException() {
         registerer = new Registerer(null, null, null);
-        Disconnectable disconnectable = mock(Disconnectable.class);
 
+        Disconnectable disconnectable = mock(Disconnectable.class);
         registerer.registerDisconnectable(disconnectable);
     }
 
     @Test(expected = MerlinException.class)
-    public void throwADeveloperExceptionWhenAOnBinderIsNotSetButRegisterBindableIsCalled() throws Exception {
+    public void givenMissingBinder_whenRegisteringBindable_thenThrowsDeveloperException() {
         registerer = new Registerer(null, null, null);
-        Bindable bindable = mock(Bindable.class);
 
+        Bindable bindable = mock(Bindable.class);
         registerer.registerBindable(bindable);
     }
 
     @Test
-    public void registerObjectsWhichImplementConnectable() throws Exception {
-        MerlinConnector<Connectable> connector = mock(MerlinConnector.class);
-        Registerer registerer = new Registerer(connector, null, null);
-        ConnectableClassImpl reconnectableClass = new ConnectableClassImpl();
+    public void givenConnector_whenRegisteringConnectable_thenRegistersConnectableWithConnector() {
+        Connectable connectable = mock(Connectable.class);
 
-        registerer.registerConnectable(reconnectableClass);
+        registerer.registerConnectable(connectable);
 
-        verify(connector).register(reconnectableClass);
+        verify(connector).register(connectable);
     }
 
     @Test
-    public void registerObjectsWhichImplementDisconnectable() throws Exception {
-        MerlinConnector<Disconnectable> disconnector = mock(MerlinConnector.class);
-        Registerer registerer = new Registerer(null, disconnector, null);
-        DisconnectableImpl disconnectableImpl = new DisconnectableImpl();
+    public void givenDisconnector_whenRegisteringDisconnectable_thenRegistersDisconnectableWithDisconnector() {
+        Disconnectable disconnectable = mock(Disconnectable.class);
 
-        registerer.registerDisconnectable(disconnectableImpl);
+        registerer.registerDisconnectable(disconnectable);
 
-        verify(disconnector).register(disconnectableImpl);
+        verify(disconnector).register(disconnectable);
     }
 
     @Test
-    public void registerObjectsWhichImplementBindable() throws Exception {
-        MerlinConnector<Bindable> onBinder = mock(MerlinConnector.class);
-        Registerer registerer = new Registerer(null, null, onBinder);
-        BindableImpl disconnectableImpl = new BindableImpl();
+    public void givenBinder_whenRegisteringBindable_thenRegistersBindableWithBinder() {
+        Bindable bindable = mock(Bindable.class);
 
-        registerer.registerBindable(disconnectableImpl);
+        registerer.registerBindable(bindable);
 
-        verify(onBinder).register(disconnectableImpl);
+        verify(binder).register(bindable);
     }
 
     @Test
-    public void notRegisterObjectsWhichDoNotImplementReconnectable() throws Exception {
-        NonRegisterableClass nonReconnectableClass = new NonRegisterableClass();
+    public void givenRegisterer_whenRegisteringNonRegisterable_thenDoesNotRegister() {
+        Object nonRegisterableObject = new Object();
         MerlinConnector<Connectable> merlinConnector = mock(MerlinConnector.class);
         MerlinConnector<Disconnectable> merlinDisconnector = mock(MerlinConnector.class);
         MerlinConnector<Bindable> merlinOnBinder = mock(MerlinConnector.class);
         Registerer registerer = new Registerer(merlinConnector, merlinDisconnector, merlinOnBinder);
 
-        registerer.register(nonReconnectableClass);
+        registerer.register(nonRegisterableObject);
 
         verify(merlinConnector, never()).register(any(Connectable.class));
         verify(merlinDisconnector, never()).register(any(Disconnectable.class));
         verify(merlinOnBinder, never()).register(any(Bindable.class));
-    }
-
-    private static class ConnectableClassImpl implements Connectable {
-        @Override
-        public void onConnect() {
-        }
-    }
-
-    private static class DisconnectableImpl implements Disconnectable {
-        @Override
-        public void onDisconnect() {
-        }
-    }
-
-    private static class BindableImpl implements Bindable {
-        @Override
-        public void onBind(NetworkStatus networkStatus) {
-        }
-    }
-
-    private static class NonRegisterableClass {
     }
 
 }

--- a/core/src/test/java/com/novoda/merlin/registerable/RegistererTest.java
+++ b/core/src/test/java/com/novoda/merlin/registerable/RegistererTest.java
@@ -87,16 +87,12 @@ public class RegistererTest {
     @Test
     public void givenRegisterer_whenRegisteringNonRegisterable_thenDoesNotRegister() {
         Object nonRegisterableObject = new Object();
-        MerlinConnector<Connectable> merlinConnector = mock(MerlinConnector.class);
-        MerlinConnector<Disconnectable> merlinDisconnector = mock(MerlinConnector.class);
-        MerlinConnector<Bindable> merlinOnBinder = mock(MerlinConnector.class);
-        Registerer registerer = new Registerer(merlinConnector, merlinDisconnector, merlinOnBinder);
 
         registerer.register(nonRegisterableObject);
 
-        verify(merlinConnector, never()).register(any(Connectable.class));
-        verify(merlinDisconnector, never()).register(any(Disconnectable.class));
-        verify(merlinOnBinder, never()).register(any(Bindable.class));
+        verifyZeroInteractions(connector);
+        verifyZeroInteractions(disconnector);
+        verifyZeroInteractions(binder);
     }
 
 }

--- a/core/src/test/java/com/novoda/merlin/registerable/bind/BinderTest.java
+++ b/core/src/test/java/com/novoda/merlin/registerable/bind/BinderTest.java
@@ -25,12 +25,12 @@ public class BinderTest {
 
     private MerlinConnector<Bindable> merlinBinder;
 
-    private OnBinder binder;
+    private Binder binder;
 
     @Before
     public void setUp() {
         merlinBinder = new MerlinRegisterer<>();
-        binder = new OnBinder(merlinBinder);
+        binder = new Binder(merlinBinder);
     }
 
     @Test

--- a/core/src/test/java/com/novoda/merlin/registerable/bind/BinderTest.java
+++ b/core/src/test/java/com/novoda/merlin/registerable/bind/BinderTest.java
@@ -1,0 +1,73 @@
+package com.novoda.merlin.registerable.bind;
+
+import com.novoda.merlin.NetworkStatus;
+import com.novoda.merlin.registerable.MerlinConnector;
+import com.novoda.merlin.registerable.MerlinRegisterer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+public class BinderTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private NetworkStatus networkStatus;
+
+    private MerlinConnector<Bindable> merlinBinder;
+
+    private OnBinder binder;
+
+    @Before
+    public void setUp() {
+        merlinBinder = new MerlinRegisterer<>();
+        binder = new OnBinder(merlinBinder);
+    }
+
+    @Test
+    public void givenRegisteredConnectable_whenCallingOnConnect_thenCallsConnectForConnectable() {
+        Bindable bindable = givenRegisteredBindable();
+
+        binder.onMerlinBind(networkStatus);
+
+        Mockito.verify(bindable).onBind(networkStatus);
+    }
+
+    @Test
+    public void givenMultipleRegisteredConnectables_whenCallingOnConnect_thenCallsConnectForAllConnectables() {
+        List<Bindable> bindables = givenMultipleRegisteredBindables();
+
+        binder.onMerlinBind(networkStatus);
+
+        for (Bindable bindable : bindables) {
+            Mockito.verify(bindable).onBind(networkStatus);
+        }
+    }
+
+    private List<Bindable> givenMultipleRegisteredBindables() {
+        List<Bindable> bindables = new ArrayList<>();
+
+        for (int i = 0; i < 3; i++) {
+            Bindable connectable = Mockito.mock(Bindable.class);
+            bindables.add(connectable);
+            merlinBinder.register(connectable);
+        }
+        return bindables;
+    }
+
+    private Bindable givenRegisteredBindable() {
+        Bindable bindable = Mockito.mock(Bindable.class);
+        merlinBinder.register(bindable);
+        return bindable;
+    }
+
+}

--- a/core/src/test/java/com/novoda/merlin/registerable/connection/ConnectorTest.java
+++ b/core/src/test/java/com/novoda/merlin/registerable/connection/ConnectorTest.java
@@ -7,16 +7,18 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.MockitoAnnotations.initMocks;
 
-@RunWith(JUnit4.class)
 public class ConnectorTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     private MerlinConnector<Connectable> merlinConnector;
 
@@ -24,8 +26,7 @@ public class ConnectorTest {
 
     @Before
     public void setUp() throws Exception {
-        initMocks(this);
-        merlinConnector = new MerlinRegisterer<Connectable>();
+        merlinConnector = new MerlinRegisterer<>();
         connector = new Connector(merlinConnector);
     }
 
@@ -53,7 +54,7 @@ public class ConnectorTest {
     }
 
     private List<Connectable> createListOfConnectables() {
-        List<Connectable> connectables = new ArrayList<Connectable>();
+        List<Connectable> connectables = new ArrayList<>();
         initListOfConnectables(connectables);
         return connectables;
     }

--- a/core/src/test/java/com/novoda/merlin/registerable/connection/ConnectorTest.java
+++ b/core/src/test/java/com/novoda/merlin/registerable/connection/ConnectorTest.java
@@ -25,15 +25,14 @@ public class ConnectorTest {
     private Connector connector;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         merlinConnector = new MerlinRegisterer<>();
         connector = new Connector(merlinConnector);
     }
 
     @Test
-    public void callbackRegisteredConnectables() throws Exception {
-        Connectable connectable = mock(Connectable.class);
-        merlinConnector.register(connectable);
+    public void givenRegisteredConnectable_whenCallingOnConnect_thenCallsConnectForConnectable() {
+        Connectable connectable = givenRegisteredConnectable();
 
         connector.onConnect();
 
@@ -41,10 +40,8 @@ public class ConnectorTest {
     }
 
     @Test
-    public void callbackAllRegistered() throws Exception {
-        List<Connectable> connectables = createListOfConnectables();
-
-        registerListOfConnectables(connectables);
+    public void givenMultipleRegisteredConnectables_whenCallingOnConnect_thenCallsConnectForAllConnectables() {
+        List<Connectable> connectables = givenMultipleRegisteredConnectables();
 
         connector.onConnect();
 
@@ -53,22 +50,21 @@ public class ConnectorTest {
         }
     }
 
-    private List<Connectable> createListOfConnectables() {
+    private List<Connectable> givenMultipleRegisteredConnectables() {
         List<Connectable> connectables = new ArrayList<>();
-        initListOfConnectables(connectables);
+
+        for (int i = 0; i < 3; i++) {
+            Connectable connectable = mock(Connectable.class);
+            connectables.add(connectable);
+            merlinConnector.register(connectable);
+        }
         return connectables;
     }
 
-    private void initListOfConnectables(List<Connectable> connectables) {
-        for (int i = 0; i < 3; i++) {
-            connectables.add(mock(Connectable.class));
-        }
-    }
-
-    private void registerListOfConnectables(List<Connectable> connectables) {
-        for (Connectable connectable : connectables) {
-            merlinConnector.register(connectable);
-        }
+    private Connectable givenRegisteredConnectable() {
+        Connectable connectable = mock(Connectable.class);
+        merlinConnector.register(connectable);
+        return connectable;
     }
 
 }

--- a/core/src/test/java/com/novoda/merlin/registerable/connection/ConnectorTest.java
+++ b/core/src/test/java/com/novoda/merlin/registerable/connection/ConnectorTest.java
@@ -7,18 +7,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public class ConnectorTest {
-
-    @Rule
-    public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     private MerlinConnector<Connectable> merlinConnector;
 

--- a/core/src/test/java/com/novoda/merlin/registerable/disconnection/DisconnectorTest.java
+++ b/core/src/test/java/com/novoda/merlin/registerable/disconnection/DisconnectorTest.java
@@ -15,21 +15,20 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 public class DisconnectorTest {
 
-    private MerlinConnector<Disconnectable> merlinConnector;
+    private MerlinConnector<Disconnectable> merlinDisconnector;
 
     private Disconnector disconnector;
 
     @Before
     public void setUp() {
         initMocks(this);
-        merlinConnector = new MerlinRegisterer<Disconnectable>();
-        disconnector = new Disconnector(merlinConnector);
+        merlinDisconnector = new MerlinRegisterer<>();
+        disconnector = new Disconnector(merlinDisconnector);
     }
 
     @Test
-    public void callback_registered_disconnectable() throws Exception {
-        Disconnectable disconnectable = mock(Disconnectable.class);
-        merlinConnector.register(disconnectable);
+    public void givenRegisteredDisconnectable_whenCallingOnDisconect_thenCallsDisconnectForDisconnectable() {
+        Disconnectable disconnectable = givenRegisteredDisconnectable();
 
         disconnector.onDisconnect();
 
@@ -37,10 +36,8 @@ public class DisconnectorTest {
     }
 
     @Test
-    public void callback_registered_disconnectables() throws Exception {
-        List<Disconnectable> disconnectables = new ArrayList<Disconnectable>(3);
-        init_disconnectables_list(disconnectables);
-        register_disconnectables_list(disconnectables);
+    public void givenMultipleRegisteredDisconnectables_whenCallingOnConnect_thenCallsConnectForAllDisconnectables() {
+        List<Disconnectable> disconnectables = givenMultipleRegisteredDisconnectables();
 
         disconnector.onDisconnect();
 
@@ -49,16 +46,22 @@ public class DisconnectorTest {
         }
     }
 
-    private void init_disconnectables_list(List<Disconnectable> disconnectables) {
+    private List<Disconnectable> givenMultipleRegisteredDisconnectables() {
+        List<Disconnectable> disconnectables = new ArrayList<>(3);
+
         for (int disconnectableIndex = 0; disconnectableIndex < disconnectables.size(); disconnectableIndex++) {
-            disconnectables.add(mock(Disconnectable.class));
+            Disconnectable disconnectable = mock(Disconnectable.class);
+            disconnectables.add(disconnectable);
+            merlinDisconnector.register(disconnectable);
         }
+
+        return disconnectables;
     }
 
-    private void register_disconnectables_list(List<Disconnectable> disconnectables) {
-        for (Disconnectable disconnectable : disconnectables) {
-            merlinConnector.register(disconnectable);
-        }
+    private Disconnectable givenRegisteredDisconnectable() {
+        Disconnectable disconnectable = mock(Disconnectable.class);
+        merlinDisconnector.register(disconnectable);
+        return disconnectable;
     }
 
 }

--- a/core/src/test/java/com/novoda/merlin/service/HostPingerTest.java
+++ b/core/src/test/java/com/novoda/merlin/service/HostPingerTest.java
@@ -2,14 +2,11 @@ package com.novoda.merlin.service;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-@RunWith(JUnit4.class)
 public class HostPingerTest {
 
     private static final String HOST_ADDRESS = "any host address";

--- a/core/src/test/java/com/novoda/merlin/service/HostPingerTest.java
+++ b/core/src/test/java/com/novoda/merlin/service/HostPingerTest.java
@@ -1,42 +1,56 @@
 package com.novoda.merlin.service;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
-import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 public class HostPingerTest {
 
     private static final String HOST_ADDRESS = "any host address";
 
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private PingTask pingTask;
+    @Mock
+    private PingTaskFactory pingTaskFactory;
+    @Mock
+    private HostPinger.PingerCallback pingerCallback;
+
     private HostPinger hostPinger;
 
-    @Mock
-    private PingTask mockPingTask;
-    @Mock
-    private PingTaskFactory mockPingTaskFactory;
-
     @Before
-    public void setUp() throws Exception {
-        initMocks(this);
-        when(mockPingTaskFactory.create(HOST_ADDRESS)).thenReturn(mockPingTask);
-        hostPinger = new HostPinger(mock(HostPinger.PingerCallback.class), HOST_ADDRESS, mockPingTaskFactory);
+    public void setUp() {
+        given(pingTaskFactory.create(HOST_ADDRESS)).willReturn(pingTask);
+        hostPinger = new HostPinger(pingerCallback, HOST_ADDRESS, pingTaskFactory);
     }
 
     @Test
-    public void createsPingTaskWhenPing() {
+    public void whenPinging_thenCreatesPingTask() {
         hostPinger.ping();
 
-        verify(mockPingTaskFactory).create(HOST_ADDRESS);
+        verify(pingTaskFactory).create(HOST_ADDRESS);
     }
 
     @Test
-    public void createsExecutesPingTaskWhenPing() {
+    public void whenPinging_thenExecutesPingTask() {
         hostPinger.ping();
 
-        verify(mockPingTask).execute();
+        verify(pingTask).execute();
+    }
+
+    @Test
+    public void whenNoNetworkToPing_thenCallsOnFailure() {
+        hostPinger.noNetworkToPing();
+
+        verify(pingerCallback).onFailure();
     }
 
 }

--- a/core/src/test/java/com/novoda/merlin/service/MerlinServiceTest.java
+++ b/core/src/test/java/com/novoda/merlin/service/MerlinServiceTest.java
@@ -5,9 +5,7 @@ import android.content.Context;
 import android.content.ContextWrapper;
 import android.content.Intent;
 import android.net.ConnectivityManager;
-import android.support.annotation.NonNull;
 
-import com.novoda.merlin.NetworkStatus;
 import com.novoda.merlin.receiver.ConnectivityChangeEvent;
 import com.novoda.merlin.registerable.connection.ConnectListener;
 import com.novoda.merlin.registerable.disconnection.DisconnectListener;
@@ -19,9 +17,14 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class MerlinServiceTest {
+
+    private static final boolean IS_CONNECTED = true;
+    private static final boolean NOT_CONNECTED = false;
 
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
@@ -34,11 +37,17 @@ public class MerlinServiceTest {
     private ConnectListener connectListener;
     @Mock
     private DisconnectListener disconnectListener;
+    @Mock
+    private HostPinger defaultPinger;
+    @Mock
+    private HostPinger customPinger;
+    @Mock
+    private NetworkStatusRetriever networkStatusRetriever;
 
     private MerlinService merlinService;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         merlinService = new MerlinService() {
 
             @Override
@@ -58,9 +67,8 @@ public class MerlinServiceTest {
     }
 
     @Test
-    public void callMerlinNetworkListenerOnConnectedWhenAConnectedConnectivityEventIsTriggered() throws Exception {
-        boolean isConnected = true;
-        ConnectivityChangeEvent connectivityChangeEvent = createConnectivityChangeEvent(isConnected);
+    public void givenConnectedEvent_whenConnectivityChanges_thenCallsOnConnect() {
+        ConnectivityChangeEvent connectivityChangeEvent = createConnectivityChangeEvent(IS_CONNECTED);
 
         merlinService.onConnectivityChanged(connectivityChangeEvent);
 
@@ -68,9 +76,8 @@ public class MerlinServiceTest {
     }
 
     @Test
-    public void callMerlinNetworkListenerOnDisconnectedWhenAConnectedConnectivityEventIsTriggered() throws Exception {
-        boolean isConnected = false;
-        ConnectivityChangeEvent connectivityChangeEvent = createConnectivityChangeEvent(isConnected);
+    public void givenDisconnectedEvent_whenConnectivityChanges_thenCallsOnDisconnect() {
+        ConnectivityChangeEvent connectivityChangeEvent = createConnectivityChangeEvent(NOT_CONNECTED);
 
         merlinService.onConnectivityChanged(connectivityChangeEvent);
 
@@ -78,47 +85,41 @@ public class MerlinServiceTest {
     }
 
     @Test
-    public void useDefaultNetworkStatusRetrieverWhenPingingDefaultEndpoint() {
+    public void givenConnectedEvent_whenConnectivityChanges_thenFetchesUsingDefaultPinger() {
         ContextWrapper contextWrapper = stubbedContextWrapper();
 
-        NetworkStatusRetriever mockRetriever = mock(NetworkStatusRetriever.class);
-        HostPinger mockDefaultPinger = mock(HostPinger.class);
-        HostPinger mockCustomPinger = mock(HostPinger.class);
-
-        MerlinService merlinService = buildStubbedMerlinService(contextWrapper, mockRetriever, mockDefaultPinger, mockCustomPinger);
+        MerlinService merlinService = buildStubbedMerlinService(contextWrapper, networkStatusRetriever, defaultPinger, customPinger);
 
         merlinService.onCreate();
-        merlinService.onConnectivityChanged(networkAvailableEvent());
-        verify(mockRetriever).fetchWithPing(mockDefaultPinger);
+        merlinService.onConnectivityChanged(createConnectivityChangeEvent(IS_CONNECTED));
+        verify(networkStatusRetriever).fetchWithPing(defaultPinger);
     }
 
     @Test
-    public void useCustomNetworkStatusRetrieverWhenPingingCustomEndpoint() {
+    public void givenConnectedEvent_andCustomEndpoint_whenConnectivityChanges_thenFetchesUsingCustomPinger() {
         ContextWrapper contextWrapper = stubbedContextWrapper();
 
-        NetworkStatusRetriever mockRetriever = mock(NetworkStatusRetriever.class);
-        HostPinger mockDefaultPinger = mock(HostPinger.class);
-        HostPinger mockCustomPinger = mock(HostPinger.class);
-
-        MerlinService merlinService = buildStubbedMerlinService(contextWrapper, mockRetriever, mockDefaultPinger, mockCustomPinger);
+        MerlinService merlinService = buildStubbedMerlinService(contextWrapper, networkStatusRetriever, defaultPinger, customPinger);
 
         merlinService.onCreate();
         merlinService.setHostname("some new host name", mock(ResponseCodeValidator.class));
-        merlinService.onConnectivityChanged(networkAvailableEvent());
-        verify(mockRetriever).fetchWithPing(mockCustomPinger);
+        merlinService.onConnectivityChanged(createConnectivityChangeEvent(IS_CONNECTED));
+        verify(networkStatusRetriever).fetchWithPing(customPinger);
     }
 
-    @NonNull
     private ContextWrapper stubbedContextWrapper() {
         Context context = mock(Context.class);
         ContextWrapper contextWrapper = mock(ContextWrapper.class);
         ConnectivityManager connectivityManager = mock(ConnectivityManager.class);
-        when(contextWrapper.getApplicationContext()).thenReturn(context);
-        when(context.getSystemService(Context.CONNECTIVITY_SERVICE)).thenReturn(connectivityManager);
+        given(contextWrapper.getApplicationContext()).willReturn(context);
+        given(context.getSystemService(Context.CONNECTIVITY_SERVICE)).willReturn(connectivityManager);
         return contextWrapper;
     }
 
-    @NonNull
+    private ConnectivityChangeEvent createConnectivityChangeEvent(boolean isConnected) {
+        return ConnectivityChangeEvent.createWithNetworkInfoChangeEvent(isConnected, "info", "reason");
+    }
+
     private MerlinService buildStubbedMerlinService(
             ContextWrapper contextWrapper,
             NetworkStatusRetriever retriever,
@@ -131,17 +132,6 @@ public class MerlinServiceTest {
                 defaultPinger,
                 customPinger
         );
-    }
-
-    @NonNull
-    private ConnectivityChangeEvent networkAvailableEvent() {
-        ConnectivityChangeEvent connectivityChangeEvent = mock(ConnectivityChangeEvent.class);
-        when(connectivityChangeEvent.asNetworkStatus()).thenReturn(NetworkStatus.newAvailableInstance());
-        return connectivityChangeEvent;
-    }
-
-    private ConnectivityChangeEvent createConnectivityChangeEvent(boolean isConnected) {
-        return ConnectivityChangeEvent.createWithNetworkInfoChangeEvent(isConnected, "info", "reason");
     }
 
 }

--- a/core/src/test/java/com/novoda/merlin/service/MerlinServiceTest.java
+++ b/core/src/test/java/com/novoda/merlin/service/MerlinServiceTest.java
@@ -13,13 +13,18 @@ import com.novoda.merlin.registerable.connection.ConnectListener;
 import com.novoda.merlin.registerable.disconnection.DisconnectListener;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 public class MerlinServiceTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Mock
     private Intent intent;
@@ -34,7 +39,6 @@ public class MerlinServiceTest {
 
     @Before
     public void setUp() throws Exception {
-        initMocks(this);
         merlinService = new MerlinService() {
 
             @Override
@@ -43,7 +47,7 @@ public class MerlinServiceTest {
 
             @Override
             public void onConnectivityChanged(ConnectivityChangeEvent connectivityChangeEvent) {
-                // TODO : this is bad, but I blame not having a proper constructor
+                // TODO : See https://github.com/novoda/merlin/issues/112
                 if (connectivityChangeEvent.isConnected()) {
                     connectListener.onConnect();
                 } else {

--- a/core/src/test/java/com/novoda/merlin/service/MerlinServiceTest.java
+++ b/core/src/test/java/com/novoda/merlin/service/MerlinServiceTest.java
@@ -14,14 +14,11 @@ import com.novoda.merlin.registerable.disconnection.DisconnectListener;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-@RunWith(JUnit4.class)
 public class MerlinServiceTest {
 
     @Mock

--- a/core/src/test/java/com/novoda/merlin/service/NetworkStatusRetrieverTest.java
+++ b/core/src/test/java/com/novoda/merlin/service/NetworkStatusRetrieverTest.java
@@ -4,54 +4,57 @@ import com.novoda.merlin.MerlinsBeard;
 import com.novoda.merlin.NetworkStatus;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 public class NetworkStatusRetrieverTest {
 
     private static boolean CONNECTED = true;
     private static boolean DISCONNECTED = false;
 
-    @Mock
-    private MerlinsBeard mockMerlinsBeards;
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Mock
-    private HostPinger mockHostPinger;
+    private MerlinsBeard merlinsBeards;
+    @Mock
+    private HostPinger hostPinger;
 
     private NetworkStatusRetriever networkStatusRetriever;
 
     @Before
     public void setUp() {
-        initMocks(this);
-        networkStatusRetriever = new NetworkStatusRetriever(mockMerlinsBeards);
+        networkStatusRetriever = new NetworkStatusRetriever(merlinsBeards);
     }
 
     @Test
     public void givenMerlinsBeardIsConnected_whenFetchingWithPing_thenPingsUsingHostPinger() {
-        given(mockMerlinsBeards.isConnected()).willReturn(CONNECTED);
+        given(merlinsBeards.isConnected()).willReturn(CONNECTED);
 
-        networkStatusRetriever.fetchWithPing(mockHostPinger);
+        networkStatusRetriever.fetchWithPing(hostPinger);
 
-        verify(mockHostPinger).ping();
+        verify(hostPinger).ping();
     }
 
     @Test
     public void givenMerlinsBeardIsDisconnected_whenFetchingWithPing_thenCallsNoNetworkToPing() {
-        given(mockMerlinsBeards.isConnected()).willReturn(DISCONNECTED);
+        given(merlinsBeards.isConnected()).willReturn(DISCONNECTED);
 
-        networkStatusRetriever.fetchWithPing(mockHostPinger);
+        networkStatusRetriever.fetchWithPing(hostPinger);
 
-        verify(mockHostPinger).noNetworkToPing();
+        verify(hostPinger).noNetworkToPing();
     }
 
     @Test
     public void givenMerlinsBeardIsConnected_whenGettingNetworkStatus_thenReturnsNetworkStatusAvailable() {
-        given(mockMerlinsBeards.isConnected()).willReturn(CONNECTED);
+        given(merlinsBeards.isConnected()).willReturn(CONNECTED);
 
         NetworkStatus networkStatus = networkStatusRetriever.get();
 
@@ -60,7 +63,7 @@ public class NetworkStatusRetrieverTest {
 
     @Test
     public void givenMerlinsBeardIsDisconnected_whenGettingNetworkStatus_thenReturnsNetworkStatusUnavailable() {
-        given(mockMerlinsBeards.isConnected()).willReturn(DISCONNECTED);
+        given(merlinsBeards.isConnected()).willReturn(DISCONNECTED);
 
         NetworkStatus networkStatus = networkStatusRetriever.get();
 

--- a/core/src/test/java/com/novoda/merlin/service/NetworkStatusRetrieverTest.java
+++ b/core/src/test/java/com/novoda/merlin/service/NetworkStatusRetrieverTest.java
@@ -8,11 +8,14 @@ import org.junit.Test;
 import org.mockito.Mock;
 
 import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class NetworkStatusRetrieverTest {
+
+    private static boolean CONNECTED = true;
+    private static boolean DISCONNECTED = false;
 
     @Mock
     private MerlinsBeard mockMerlinsBeards;
@@ -29,8 +32,8 @@ public class NetworkStatusRetrieverTest {
     }
 
     @Test
-    public void whenNetworkIsConnectedHostPingerPings() {
-        when(mockMerlinsBeards.isConnected()).thenReturn(true);
+    public void givenMerlinsBeardIsConnected_whenFetchingWithPing_thenPingsUsingHostPinger() {
+        given(mockMerlinsBeards.isConnected()).willReturn(CONNECTED);
 
         networkStatusRetriever.fetchWithPing(mockHostPinger);
 
@@ -38,8 +41,8 @@ public class NetworkStatusRetrieverTest {
     }
 
     @Test
-    public void whenNetworkIsDisconnectedHostPingerPerformsNoNetworkToPing() {
-        when(mockMerlinsBeards.isConnected()).thenReturn(false);
+    public void givenMerlinsBeardIsDisconnected_whenFetchingWithPing_thenCallsNoNetworkToPing() {
+        given(mockMerlinsBeards.isConnected()).willReturn(DISCONNECTED);
 
         networkStatusRetriever.fetchWithPing(mockHostPinger);
 
@@ -47,8 +50,8 @@ public class NetworkStatusRetrieverTest {
     }
 
     @Test
-    public void whenNetworkIsConnectedGetWithoutPingReturnsNetworkStatusAvailable() {
-        when(mockMerlinsBeards.isConnected()).thenReturn(true);
+    public void givenMerlinsBeardIsConnected_whenGettingNetworkStatus_thenReturnsNetworkStatusAvailable() {
+        given(mockMerlinsBeards.isConnected()).willReturn(CONNECTED);
 
         NetworkStatus networkStatus = networkStatusRetriever.get();
 
@@ -56,8 +59,8 @@ public class NetworkStatusRetrieverTest {
     }
 
     @Test
-    public void whenNetworkIsDisconnectedGetWithoutPingReturnsNetworkStatusUnavailable() {
-        when(mockMerlinsBeards.isConnected()).thenReturn(false);
+    public void givenMerlinsBeardIsDisconnected_whenGettingNetworkStatus_thenReturnsNetworkStatusUnavailable() {
+        given(mockMerlinsBeards.isConnected()).willReturn(DISCONNECTED);
 
         NetworkStatus networkStatus = networkStatusRetriever.get();
 

--- a/core/src/test/java/com/novoda/merlin/service/PingTest.java
+++ b/core/src/test/java/com/novoda/merlin/service/PingTest.java
@@ -6,8 +6,6 @@ import java.io.IOException;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
 import static com.novoda.merlin.service.HostPinger.ResponseCodeFetcher;
@@ -16,7 +14,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-@RunWith(Enclosed.class)
 public class PingTest {
 
     private static final String HOST_ADDRESS = "any host address";

--- a/core/src/test/java/com/novoda/merlin/service/ResponseCodeValidatorTest.java
+++ b/core/src/test/java/com/novoda/merlin/service/ResponseCodeValidatorTest.java
@@ -5,14 +5,12 @@ import java.util.Collection;
 import java.util.List;
 
 import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import static com.novoda.merlin.service.ResponseCodeValidator.DefaultEndpointResponseCodeValidator;
 import static org.fest.assertions.api.Assertions.assertThat;
 
-@RunWith(Enclosed.class)
 public class ResponseCodeValidatorTest {
 
     @RunWith(Parameterized.class)

--- a/core/src/test/java/com/novoda/merlin/service/ResponseCodeValidatorTest.java
+++ b/core/src/test/java/com/novoda/merlin/service/ResponseCodeValidatorTest.java
@@ -30,13 +30,15 @@ public class ResponseCodeValidatorTest {
         }
 
         @Test
-        public void testOtherCodesReturnFalse() {
+        public void whenCheckingResponseCodeValidity() {
             boolean actual = new DefaultEndpointResponseCodeValidator().isResponseCodeValid(responseCode);
+
             assertThat(actual).isEqualTo(isValid);
         }
     }
 
-    enum Responses {
+    private enum Responses {
+
         OK(200, false),
         CREATED(201, false),
         NO_CONTENT(204, true),


### PR DESCRIPTION
## Problem
As per #101 Use BDD Naming, `Merlin` uses JS-like "should" notation for most of the test names in the codebase. Using "should" notation omits preconditions.

## Solution
Move to BDD notation for test names. In addition, use the BDD `Mockito` dependency to match this new notation.

### Test(s) added
Some tests were added as part of this story. Where the work required to add more tests would take longer additional GH issues were opened. 

### Screenshots
No UI changes.

### Paired with
Nobody.
