### PR TITLE
MER-106/Streamline dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,14 @@
-task wrapper(type: Wrapper) {
-    gradleVersion = '2.10'
-}
-
 allprojects {
     version = "0.10.0"
     repositories { mavenCentral() }
 }
 
 buildscript {
+    apply from: 'dependencies.gradle'
+
     repositories { jcenter() }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
-        classpath 'com.novoda:bintray-release:0.2.4'
+        classpath libraries.build.androidGradle
+        classpath libraries.build.bintrayRelease
     }
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -2,21 +2,20 @@ apply plugin: 'com.android.library'
 apply plugin: 'bintray-release'
 
 dependencies {
-    compile 'com.android.support:support-annotations:25.3.1'
+    compile libraries.app.supportAnnotations
 
-    testCompile 'org.easytesting:fest-assert-core:2.0M8'
-    testCompile 'org.mockito:mockito-core:2.7.22'
-    testCompile 'junit:junit:4.12'
+    testCompile libraries.test.jUnit
+    testCompile libraries.test.mockito
+    testCompile libraries.test.fest
 }
 
 android {
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 25
+        minSdkVersion versions.androidSdk.min
     }
 
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion versions.androidSdk.compile
+    buildToolsVersion versions.androidSdk.buildTools
 
     testOptions {
         unitTests.returnDefaultValues = true

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compile project(':merlin-rxjava')
     compile project(':merlin-rxjava2')
 
-    compile('de.keyboardsurfer.android.widget:crouton:1.7') {
+    compile(libraries.app.crouton) {
         exclude module: 'support-v4'
     }
 
@@ -14,12 +14,11 @@ dependencies {
 
 android {
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 25
+        minSdkVersion versions.androidSdk.min
     }
 
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion versions.androidSdk.compile
+    buildToolsVersion versions.androidSdk.buildTools
 
     packagingOptions {
         exclude 'META-INF/rxjava.properties'

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,0 +1,28 @@
+ext {
+    versions = [
+            support            : '25.3.1',
+            androidSdk         : [
+                    compile   : 25,
+                    min       : 14,
+                    buildTools: '25.0.2'
+            ]
+    ]
+
+    libraries = [
+            build: [
+                    androidGradle : 'com.android.tools.build:gradle:2.3.1',
+                    bintrayRelease: 'com.novoda:bintray-release:0.4.0'
+            ],
+            app  : [
+                    supportAnnotations: "com.android.support:support-annotations:${versions.support}",
+                    crouton: 'de.keyboardsurfer.android.widget:crouton:1.7',
+                    rxJava: 'io.reactivex:rxjava:1.2.10',
+                    rxJava2: 'io.reactivex.rxjava2:rxjava:2.0.9'
+            ],
+            test : [
+                    jUnit: 'junit:junit:4.12',
+                    mockito: 'org.mockito:mockito-core:2.7.22',
+                    fest: 'org.easytesting:fest-assert-core:2.0M8'
+            ]
+    ]
+}

--- a/merlin-rxjava/build.gradle
+++ b/merlin-rxjava/build.gradle
@@ -3,22 +3,21 @@ apply plugin: 'bintray-release'
 
 dependencies {
     compile project(':core')
-    compile 'com.android.support:support-annotations:25.3.1'
-    compile 'io.reactivex:rxjava:1.2.10'
+    compile libraries.app.supportAnnotations
+    compile libraries.app.rxJava
 
-    testCompile 'org.easytesting:fest-assert-core:2.0M8'
-    testCompile 'org.mockito:mockito-core:2.7.22'
-    testCompile 'junit:junit:4.12'
+    testCompile libraries.test.jUnit
+    testCompile libraries.test.mockito
+    testCompile libraries.test.fest
 }
 
 android {
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 25
+        minSdkVersion versions.androidSdk.min
     }
 
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion versions.androidSdk.compile
+    buildToolsVersion versions.androidSdk.buildTools
 }
 
 publish {

--- a/merlin-rxjava2/build.gradle
+++ b/merlin-rxjava2/build.gradle
@@ -3,23 +3,23 @@ apply plugin: 'bintray-release'
 
 dependencies {
     compile project(':core')
-    compile 'com.android.support:support-annotations:25.3.1'
-    compile 'io.reactivex.rxjava2:rxjava:2.0.9'
+    compile libraries.app.supportAnnotations
+    compile libraries.app.rxJava2
 
-    testCompile 'org.easytesting:fest-assert-core:2.0M8'
-    testCompile 'org.mockito:mockito-core:2.7.22'
-    testCompile 'junit:junit:4.12'
+    testCompile libraries.test.jUnit
+    testCompile libraries.test.mockito
+    testCompile libraries.test.fest
 }
 
 android {
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 25
+        minSdkVersion versions.androidSdk.min
     }
 
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion versions.androidSdk.compile
+    buildToolsVersion versions.androidSdk.buildTools
 }
+
 
 publish {
     userOrg = 'novoda'


### PR DESCRIPTION
## Problem
We have `gradle.build` files for each of our modules, each of these specify a list of dependency. This can add up to a lot of dependencies which makes it difficult to track and update.

## Solution
Create a single `dependencies.gradle` file where all of the project's dependencies can be listed. This file can then be referenced in each of the `build.gradle` files.

### Test(s) added
No, just tidying dependencies.

### Screenshots
No UI changes.

### Paired with
Nobody.
