### PR TITLE
MER-118/Endpoint in place of String

### DIFF
--- a/core/src/main/java/com/novoda/merlin/Endpoint.java
+++ b/core/src/main/java/com/novoda/merlin/Endpoint.java
@@ -1,5 +1,8 @@
 package com.novoda.merlin;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+
 public class Endpoint {
 
     private static final Endpoint DEFAULT_ENDPOINT = Endpoint.from("http://connectivitycheck.android.com/generate_204");
@@ -18,8 +21,8 @@ public class Endpoint {
         this.endpoint = endpoint;
     }
 
-    public String asString() {
-        return endpoint;
+    public URL asURL() throws MalformedURLException {
+        return new URL(endpoint);
     }
 
     @Override

--- a/core/src/main/java/com/novoda/merlin/Endpoint.java
+++ b/core/src/main/java/com/novoda/merlin/Endpoint.java
@@ -23,6 +23,13 @@ public class Endpoint {
     }
 
     @Override
+    public String toString() {
+        return "Endpoint{" +
+                "endpoint='" + endpoint + '\'' +
+                '}';
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/core/src/main/java/com/novoda/merlin/Endpoint.java
+++ b/core/src/main/java/com/novoda/merlin/Endpoint.java
@@ -1,0 +1,44 @@
+package com.novoda.merlin;
+
+public class Endpoint {
+
+    private static final Endpoint DEFAULT_ENDPOINT = Endpoint.from("http://connectivitycheck.android.com/generate_204");
+
+    private final String endpoint;
+
+    public static Endpoint defaultEndpoint() {
+        return DEFAULT_ENDPOINT;
+    }
+
+    public static Endpoint from(String endpoint) {
+        return new Endpoint(endpoint);
+    }
+
+    private Endpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public String asString() {
+        return endpoint;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Endpoint endpoint1 = (Endpoint) o;
+
+        return endpoint != null ? endpoint.equals(endpoint1.endpoint) : endpoint1.endpoint == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        return endpoint != null ? endpoint.hashCode() : 0;
+    }
+}

--- a/core/src/main/java/com/novoda/merlin/Merlin.java
+++ b/core/src/main/java/com/novoda/merlin/Merlin.java
@@ -19,7 +19,7 @@ public class Merlin {
         this.registerer = registerer;
     }
 
-    public void setEndpoint(String endpoint, ResponseCodeValidator validator) {
+    public void setEndpoint(Endpoint endpoint, ResponseCodeValidator validator) {
         merlinServiceBinder.setEndpoint(endpoint, validator);
     }
 

--- a/core/src/main/java/com/novoda/merlin/MerlinBuilder.java
+++ b/core/src/main/java/com/novoda/merlin/MerlinBuilder.java
@@ -30,7 +30,7 @@ public class MerlinBuilder {
     private MerlinRegisterer<Disconnectable> disconnectableRegisterer;
     private MerlinRegisterer<Bindable> bindableRegisterer;
 
-    private String endPoint = Merlin.DEFAULT_ENDPOINT;
+    private Endpoint endpoint = Endpoint.defaultEndpoint();
     private ResponseCodeValidator responseCodeValidator = new DefaultEndpointResponseCodeValidator();
 
     MerlinBuilder() {
@@ -82,11 +82,11 @@ public class MerlinBuilder {
      * Deprecated, use directly {@link Logger} instead. To provide backwards compatibility
      * this method will attach a new {@link MerlinBackwardsCompatibleLog}. If using multiple instances
      * of {@link Merlin} the most recent call to `withLogging` will affect all other instances of {@link Merlin}.
-     *
+     * <p>
      * Example:
-     *  MerlinInstanceOne -> withLogging(true)
-     *  MerlinInstanceTwo -> withLogging(false)
-     *  == no logs written.
+     * MerlinInstanceOne -> withLogging(true)
+     * MerlinInstanceTwo -> withLogging(false)
+     * == no logs written.
      *
      * @param withLogging by default logging is disabled. withLogging = true will attach the default {@link MerlinBackwardsCompatibleLog}
      * @return MerlinBuilder
@@ -108,7 +108,7 @@ public class MerlinBuilder {
      * @return MerlinBuilder.
      */
     public MerlinBuilder setEndPoint(String endPoint) {
-        this.endPoint = endPoint;
+        this.endpoint = Endpoint.from(endPoint);
         return this;
     }
 
@@ -135,7 +135,7 @@ public class MerlinBuilder {
                 merlinConnector,
                 merlinDisconnector,
                 merlinOnBinder,
-                endPoint,
+                endpoint,
                 responseCodeValidator
         );
 

--- a/core/src/main/java/com/novoda/merlin/MerlinBuilder.java
+++ b/core/src/main/java/com/novoda/merlin/MerlinBuilder.java
@@ -37,7 +37,7 @@ public class MerlinBuilder {
     }
 
     /**
-     * Enables Merlin to provide connectable callbacks, without calling this, Merlin.registerConnectable will throw a MerlinException
+     * Enables Merlin to provide connectable callbacks, without calling this, Merlin.registerConnectable will throw a MerlinException.
      *
      * @return MerlinBuilder.
      */
@@ -48,7 +48,7 @@ public class MerlinBuilder {
     }
 
     /**
-     * Enables Merlin to provide disconnectable callbacks, without calling this, Merlin.registerDisconnectable will throw a MerlinException
+     * Enables Merlin to provide disconnectable callbacks, without calling this, Merlin.registerDisconnectable will throw a MerlinException.
      *
      * @return MerlinBuilder.
      */
@@ -59,7 +59,7 @@ public class MerlinBuilder {
     }
 
     /**
-     * Enables Merlin to provide bindable callbacks, without calling this, Merlin.registerBindable will throw a MerlinException
+     * Enables Merlin to provide bindable callbacks, without calling this, Merlin.registerBindable will throw a MerlinException.
      *
      * @return MerlinBuilder.
      */
@@ -70,7 +70,8 @@ public class MerlinBuilder {
     }
 
     /**
-     * Enables Merlin to provide connectable, disconnectable & bindable callbacks, without calling this, Merlin.registerConconnectable, Merlin.registerDisconnectable, Merlin.registerBindable & Merlin.getConnectionStatusObservable will throw a MerlinException
+     * Enables Merlin to provide connectable, disconnectable & bindable callbacks, without calling this, Merlin.registerConconnectable,
+     * Merlin.registerDisconnectable, Merlin.registerBindable & Merlin.getConnectionStatusObservable will throw a MerlinException.
      *
      * @return MerlinBuilder.
      */
@@ -102,18 +103,18 @@ public class MerlinBuilder {
     }
 
     /**
-     * Sets custom endpoint
+     * Sets custom endpoint.
      *
-     * @param endPoint by default "http://connectivitycheck.android.com/generate_204".
+     * @param endpoint by default "http://connectivitycheck.android.com/generate_204".
      * @return MerlinBuilder.
      */
-    public MerlinBuilder withEndPoint(String endPoint) {
-        this.endpoint = Endpoint.from(endPoint);
+    public MerlinBuilder withEndpoint(String endpoint) {
+        this.endpoint = Endpoint.from(endpoint);
         return this;
     }
 
     /**
-     * Sets custom endpoint
+     * Sets custom endpoint.
      *
      * @param responseCodeValidator A validator implementation used for checking that the response code is what you expect.
      *                              The default endpoint returns a 204 No Content response, so the default validator checks for that.
@@ -125,7 +126,7 @@ public class MerlinBuilder {
     }
 
     /**
-     * Creates Merlin with the specified builder options
+     * Creates Merlin with the specified builder options.
      *
      * @return Merlin.
      */

--- a/core/src/main/java/com/novoda/merlin/MerlinBuilder.java
+++ b/core/src/main/java/com/novoda/merlin/MerlinBuilder.java
@@ -107,7 +107,7 @@ public class MerlinBuilder {
      * @param endPoint by default "http://connectivitycheck.android.com/generate_204".
      * @return MerlinBuilder.
      */
-    public MerlinBuilder setEndPoint(String endPoint) {
+    public MerlinBuilder withEndPoint(String endPoint) {
         this.endpoint = Endpoint.from(endPoint);
         return this;
     }
@@ -119,7 +119,7 @@ public class MerlinBuilder {
      *                              The default endpoint returns a 204 No Content response, so the default validator checks for that.
      * @return MerlinBuilder.
      */
-    public MerlinBuilder setResponseCodeValidator(ResponseCodeValidator responseCodeValidator) {
+    public MerlinBuilder withResponseCodeValidator(ResponseCodeValidator responseCodeValidator) {
         this.responseCodeValidator = responseCodeValidator;
         return this;
     }

--- a/core/src/main/java/com/novoda/merlin/service/HostPinger.java
+++ b/core/src/main/java/com/novoda/merlin/service/HostPinger.java
@@ -1,5 +1,6 @@
 package com.novoda.merlin.service;
 
+import com.novoda.merlin.Endpoint;
 import com.novoda.merlin.Merlin;
 import com.novoda.merlin.service.request.MerlinRequest;
 import com.novoda.support.Logger;
@@ -9,7 +10,7 @@ import static com.novoda.merlin.service.ResponseCodeValidator.DefaultEndpointRes
 class HostPinger {
 
     private final PingerCallback pingerCallback;
-    private final String hostAddress;
+    private final Endpoint endpoint;
     private final PingTaskFactory pingTaskFactory;
 
     interface PingerCallback {
@@ -23,22 +24,22 @@ class HostPinger {
     static HostPinger withDefaultEndpointValidation(PingerCallback pingerCallback) {
         Logger.d("Host address not set, using Merlin default: " + Merlin.DEFAULT_ENDPOINT);
         PingTaskFactory pingTaskFactory = new PingTaskFactory(pingerCallback, new ResponseCodeFetcher(), new DefaultEndpointResponseCodeValidator());
-        return new HostPinger(pingerCallback, Merlin.DEFAULT_ENDPOINT, pingTaskFactory);
+        return new HostPinger(pingerCallback, Endpoint.defaultEndpoint(), pingTaskFactory);
     }
 
-    static HostPinger withCustomEndpointAndValidation(PingerCallback pingerCallback, String hostAddress, ResponseCodeValidator validator) {
+    static HostPinger withCustomEndpointAndValidation(PingerCallback pingerCallback, Endpoint hostAddress, ResponseCodeValidator validator) {
         PingTaskFactory pingTaskFactory = new PingTaskFactory(pingerCallback, new ResponseCodeFetcher(), validator);
         return new HostPinger(pingerCallback, hostAddress, pingTaskFactory);
     }
 
-    HostPinger(PingerCallback pingerCallback, String hostAddress, PingTaskFactory pingTaskFactory) {
+    HostPinger(PingerCallback pingerCallback, Endpoint endpoint, PingTaskFactory pingTaskFactory) {
         this.pingerCallback = pingerCallback;
-        this.hostAddress = hostAddress;
+        this.endpoint = endpoint;
         this.pingTaskFactory = pingTaskFactory;
     }
 
     void ping() {
-        PingTask pingTask = pingTaskFactory.create(hostAddress);
+        PingTask pingTask = pingTaskFactory.create(endpoint);
         pingTask.execute();
     }
 
@@ -48,7 +49,7 @@ class HostPinger {
 
     static class ResponseCodeFetcher {
 
-        public int from(String endpoint) {
+        public int from(Endpoint endpoint) {
             return MerlinRequest.head(endpoint).getResponseCode();
         }
 

--- a/core/src/main/java/com/novoda/merlin/service/MerlinService.java
+++ b/core/src/main/java/com/novoda/merlin/service/MerlinService.java
@@ -7,7 +7,6 @@ import android.net.ConnectivityManager;
 import android.os.Binder;
 import android.os.IBinder;
 import android.support.annotation.VisibleForTesting;
-import android.util.Log;
 
 import com.novoda.merlin.Endpoint;
 import com.novoda.merlin.MerlinsBeard;
@@ -38,7 +37,6 @@ public class MerlinService extends Service implements HostPinger.PingerCallback 
     @Override
     public void onCreate() {
         super.onCreate();
-        Log.d(getClass().getSimpleName(), "onCreate: ");
         hostPinger = buildDefaultHostPinger();
         networkStatusRetriever = buildNetworkStatusRetriever();
         ConnectivityManager connectivityManager = (ConnectivityManager) getApplicationContext().getSystemService(Context.CONNECTIVITY_SERVICE);

--- a/core/src/main/java/com/novoda/merlin/service/MerlinService.java
+++ b/core/src/main/java/com/novoda/merlin/service/MerlinService.java
@@ -7,6 +7,7 @@ import android.net.ConnectivityManager;
 import android.os.Binder;
 import android.os.IBinder;
 import android.support.annotation.VisibleForTesting;
+import android.util.Log;
 
 import com.novoda.merlin.MerlinsBeard;
 import com.novoda.merlin.NetworkStatus;
@@ -36,6 +37,7 @@ public class MerlinService extends Service implements HostPinger.PingerCallback 
     @Override
     public void onCreate() {
         super.onCreate();
+        Log.d(getClass().getSimpleName(), "onCreate: ");
         hostPinger = buildDefaultHostPinger();
         networkStatusRetriever = buildNetworkStatusRetriever();
         ConnectivityManager connectivityManager = (ConnectivityManager) getApplicationContext().getSystemService(Context.CONNECTIVITY_SERVICE);

--- a/core/src/main/java/com/novoda/merlin/service/MerlinService.java
+++ b/core/src/main/java/com/novoda/merlin/service/MerlinService.java
@@ -9,6 +9,7 @@ import android.os.IBinder;
 import android.support.annotation.VisibleForTesting;
 import android.util.Log;
 
+import com.novoda.merlin.Endpoint;
 import com.novoda.merlin.MerlinsBeard;
 import com.novoda.merlin.NetworkStatus;
 import com.novoda.merlin.receiver.ConnectivityChangeEvent;
@@ -72,13 +73,13 @@ public class MerlinService extends Service implements HostPinger.PingerCallback 
         return super.onUnbind(intent);
     }
 
-    public void setHostname(String hostname, ResponseCodeValidator validator) {
-        hostPinger = buildHostPinger(hostname, validator);
+    public void setHostname(Endpoint endpoint, ResponseCodeValidator validator) {
+        hostPinger = buildHostPinger(endpoint, validator);
     }
 
     @VisibleForTesting
-    protected HostPinger buildHostPinger(String hostName, ResponseCodeValidator validator) {
-        return HostPinger.withCustomEndpointAndValidation(this, hostName, validator);
+    protected HostPinger buildHostPinger(Endpoint endpoint, ResponseCodeValidator validator) {
+        return HostPinger.withCustomEndpointAndValidation(this, endpoint, validator);
     }
 
     public void setBindStatusListener(BindListener bindListener) {

--- a/core/src/main/java/com/novoda/merlin/service/MerlinServiceBinder.java
+++ b/core/src/main/java/com/novoda/merlin/service/MerlinServiceBinder.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
 import android.os.IBinder;
+import android.util.Log;
 
 import com.novoda.merlin.registerable.bind.BindListener;
 import com.novoda.merlin.registerable.connection.ConnectListener;
@@ -17,7 +18,7 @@ public class MerlinServiceBinder {
     private final ListenerHolder listenerHolder;
 
     private ResponseCodeValidator validator;
-    private Connection connection;
+    private MerlinServiceConnection merlinServiceConnection;
     private String endpoint;
 
     public MerlinServiceBinder(Context context, ConnectListener connectListener, DisconnectListener disconnectListener,
@@ -34,25 +35,25 @@ public class MerlinServiceBinder {
     }
 
     public void bindService() {
-        if (connection == null) {
-            connection = new Connection(listenerHolder, endpoint, validator);
+        if (merlinServiceConnection == null) {
+            merlinServiceConnection = new MerlinServiceConnection(listenerHolder, endpoint, validator);
         }
         Intent intent = new Intent(context, MerlinService.class);
-        context.bindService(intent, connection, Context.BIND_AUTO_CREATE);
+        context.bindService(intent, merlinServiceConnection, Context.BIND_AUTO_CREATE);
     }
 
     public void unbind() {
         if (connectionIsAvailable()) {
-            context.unbindService(connection);
-            connection = null;
+            context.unbindService(merlinServiceConnection);
+            merlinServiceConnection = null;
         }
     }
 
     private boolean connectionIsAvailable() {
-        return connection != null;
+        return merlinServiceConnection != null;
     }
 
-    private static class Connection implements ServiceConnection {
+    private static class MerlinServiceConnection implements ServiceConnection {
 
         private final ListenerHolder listenerHolder;
         private final String endpoint;
@@ -60,7 +61,7 @@ public class MerlinServiceBinder {
 
         private MerlinService merlinService;
 
-        Connection(ListenerHolder listenerHolder, String endpoint, ResponseCodeValidator validator) {
+        MerlinServiceConnection(ListenerHolder listenerHolder, String endpoint, ResponseCodeValidator validator) {
             this.listenerHolder = listenerHolder;
             this.endpoint = endpoint;
             this.validator = validator;
@@ -69,6 +70,7 @@ public class MerlinServiceBinder {
         @Override
         public void onServiceConnected(ComponentName name, IBinder binder) {
             Logger.d("onServiceConnected");
+            Log.d(getClass().getSimpleName(), "onServiceConnected: ");
             merlinService = ((MerlinService.LocalBinder) binder).getService();
             merlinService.setConnectListener(listenerHolder.connectListener);
             merlinService.setDisconnectListener(listenerHolder.disconnectListener);

--- a/core/src/main/java/com/novoda/merlin/service/MerlinServiceBinder.java
+++ b/core/src/main/java/com/novoda/merlin/service/MerlinServiceBinder.java
@@ -7,6 +7,7 @@ import android.content.ServiceConnection;
 import android.os.IBinder;
 import android.util.Log;
 
+import com.novoda.merlin.Endpoint;
 import com.novoda.merlin.registerable.bind.BindListener;
 import com.novoda.merlin.registerable.connection.ConnectListener;
 import com.novoda.merlin.registerable.disconnection.DisconnectListener;
@@ -19,18 +20,18 @@ public class MerlinServiceBinder {
 
     private ResponseCodeValidator validator;
     private MerlinServiceConnection merlinServiceConnection;
-    private String endpoint;
+    private Endpoint endpoint;
 
     public MerlinServiceBinder(Context context, ConnectListener connectListener, DisconnectListener disconnectListener,
-                               BindListener bindListener, String endpoint, ResponseCodeValidator validator) {
+                               BindListener bindListener, Endpoint endpoint, ResponseCodeValidator validator) {
         this.validator = validator;
         listenerHolder = new ListenerHolder(connectListener, disconnectListener, bindListener);
         this.context = context;
         this.endpoint = endpoint;
     }
 
-    public void setEndpoint(String hostname, ResponseCodeValidator validator) {
-        this.endpoint = hostname;
+    public void setEndpoint(Endpoint endpoint, ResponseCodeValidator validator) {
+        this.endpoint = endpoint;
         this.validator = validator;
     }
 
@@ -56,12 +57,12 @@ public class MerlinServiceBinder {
     private static class MerlinServiceConnection implements ServiceConnection {
 
         private final ListenerHolder listenerHolder;
-        private final String endpoint;
+        private final Endpoint endpoint;
         private final ResponseCodeValidator validator;
 
         private MerlinService merlinService;
 
-        MerlinServiceConnection(ListenerHolder listenerHolder, String endpoint, ResponseCodeValidator validator) {
+        MerlinServiceConnection(ListenerHolder listenerHolder, Endpoint endpoint, ResponseCodeValidator validator) {
             this.listenerHolder = listenerHolder;
             this.endpoint = endpoint;
             this.validator = validator;

--- a/core/src/main/java/com/novoda/merlin/service/MerlinServiceBinder.java
+++ b/core/src/main/java/com/novoda/merlin/service/MerlinServiceBinder.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
 import android.os.IBinder;
-import android.util.Log;
 
 import com.novoda.merlin.Endpoint;
 import com.novoda.merlin.registerable.bind.BindListener;
@@ -71,7 +70,6 @@ public class MerlinServiceBinder {
         @Override
         public void onServiceConnected(ComponentName name, IBinder binder) {
             Logger.d("onServiceConnected");
-            Log.d(getClass().getSimpleName(), "onServiceConnected: ");
             merlinService = ((MerlinService.LocalBinder) binder).getService();
             merlinService.setConnectListener(listenerHolder.connectListener);
             merlinService.setDisconnectListener(listenerHolder.disconnectListener);

--- a/core/src/main/java/com/novoda/merlin/service/Ping.java
+++ b/core/src/main/java/com/novoda/merlin/service/Ping.java
@@ -1,24 +1,25 @@
 package com.novoda.merlin.service;
 
+import com.novoda.merlin.Endpoint;
 import com.novoda.merlin.service.request.RequestException;
 import com.novoda.support.Logger;
 
 class Ping {
 
-    private final String hostAddress;
+    private final Endpoint endpoint;
     private final HostPinger.ResponseCodeFetcher responseCodeFetcher;
     private final ResponseCodeValidator validator;
 
-    Ping(String hostAddress, HostPinger.ResponseCodeFetcher responseCodeFetcher, ResponseCodeValidator validator) {
-        this.hostAddress = hostAddress;
+    Ping(Endpoint endpoint, HostPinger.ResponseCodeFetcher responseCodeFetcher, ResponseCodeValidator validator) {
+        this.endpoint = endpoint;
         this.responseCodeFetcher = responseCodeFetcher;
         this.validator = validator;
     }
 
     public boolean doSynchronousPing() {
-        Logger.d("Pinging: " + hostAddress);
+        Logger.d("Pinging: " + endpoint);
         try {
-            return validator.isResponseCodeValid(responseCodeFetcher.from(hostAddress));
+            return validator.isResponseCodeValid(responseCodeFetcher.from(endpoint));
         } catch (RequestException e) {
             if (!e.causedByIO()) {
                 Logger.e("Ping task failed due to " + e.getMessage());

--- a/core/src/main/java/com/novoda/merlin/service/PingTaskFactory.java
+++ b/core/src/main/java/com/novoda/merlin/service/PingTaskFactory.java
@@ -1,5 +1,7 @@
 package com.novoda.merlin.service;
 
+import com.novoda.merlin.Endpoint;
+
 import static com.novoda.merlin.service.HostPinger.PingerCallback;
 import static com.novoda.merlin.service.HostPinger.ResponseCodeFetcher;
 
@@ -15,8 +17,8 @@ class PingTaskFactory {
         this.responseCodeValidator = responseCodeValidator;
     }
 
-    public PingTask create(String hostAddress) {
-        Ping ping = new Ping(hostAddress, responseCodeFetcher, responseCodeValidator);
+    public PingTask create(Endpoint endpoint) {
+        Ping ping = new Ping(endpoint, responseCodeFetcher, responseCodeValidator);
         return new PingTask(ping, pingerCallback);
     }
 

--- a/core/src/main/java/com/novoda/merlin/service/request/HttpRequestMaker.java
+++ b/core/src/main/java/com/novoda/merlin/service/request/HttpRequestMaker.java
@@ -4,7 +4,6 @@ import com.novoda.merlin.Endpoint;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.URL;
 
@@ -22,15 +21,13 @@ class HttpRequestMaker implements RequestMaker {
             disableRedirects(urlConnection);
 
             return new MerlinHttpRequest(urlConnection);
-        } catch (MalformedURLException e) {
-            throw new RequestException(e);
         } catch (IOException e) {
             throw new RequestException(e);
         }
     }
 
     private HttpURLConnection connectTo(Endpoint endpoint) throws IOException {
-        URL url = new URL(endpoint.asString());
+        URL url = endpoint.asURL();
         return (HttpURLConnection) url.openConnection();
     }
 

--- a/core/src/main/java/com/novoda/merlin/service/request/HttpRequestMaker.java
+++ b/core/src/main/java/com/novoda/merlin/service/request/HttpRequestMaker.java
@@ -1,5 +1,7 @@
 package com.novoda.merlin.service.request;
 
+import com.novoda.merlin.Endpoint;
+
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
@@ -11,7 +13,7 @@ class HttpRequestMaker implements RequestMaker {
     private static final String METHOD_HEAD = "HEAD";
 
     @Override
-    public Request head(String endpoint) {
+    public Request head(Endpoint endpoint) {
         try {
             HttpURLConnection urlConnection = connectTo(endpoint);
             urlConnection.setRequestProperty("Accept-Encoding", "");
@@ -27,8 +29,8 @@ class HttpRequestMaker implements RequestMaker {
         }
     }
 
-    private HttpURLConnection connectTo(String endpoint) throws IOException {
-        URL url = new URL(endpoint);
+    private HttpURLConnection connectTo(Endpoint endpoint) throws IOException {
+        URL url = new URL(endpoint.asString());
         return (HttpURLConnection) url.openConnection();
     }
 

--- a/core/src/main/java/com/novoda/merlin/service/request/MerlinRequest.java
+++ b/core/src/main/java/com/novoda/merlin/service/request/MerlinRequest.java
@@ -1,14 +1,16 @@
 package com.novoda.merlin.service.request;
 
+import com.novoda.merlin.Endpoint;
+
 public class MerlinRequest implements Request {
 
     private final Request request;
 
-    public static MerlinRequest head(String endpoint) {
+    public static MerlinRequest head(Endpoint endpoint) {
         return head(new HttpRequestMaker(), endpoint);
     }
 
-    public static MerlinRequest head(RequestMaker requestMaker, String endpoint) {
+    public static MerlinRequest head(RequestMaker requestMaker, Endpoint endpoint) {
         return new MerlinRequest(requestMaker.head(endpoint));
     }
 

--- a/core/src/main/java/com/novoda/merlin/service/request/RequestMaker.java
+++ b/core/src/main/java/com/novoda/merlin/service/request/RequestMaker.java
@@ -1,5 +1,7 @@
 package com.novoda.merlin.service.request;
 
+import com.novoda.merlin.Endpoint;
+
 interface RequestMaker {
-    Request head(String endpoint);
+    Request head(Endpoint endpoint);
 }

--- a/core/src/test/java/com/novoda/merlin/MerlinTest.java
+++ b/core/src/test/java/com/novoda/merlin/MerlinTest.java
@@ -42,12 +42,12 @@ public class MerlinTest {
 
     @Test
     public void whenBindingWithACustomEndpoint_thenSetsEndPoint() {
-        String hostname = "startTheMerlinServiceWithAHostnameWhenProvided";
+        Endpoint endpoint = Endpoint.from("startTheMerlinServiceWithAHostnameWhenProvided");
 
-        merlin.setEndpoint(hostname, validator);
+        merlin.setEndpoint(endpoint, validator);
         merlin.bind();
 
-        verify(serviceBinder).setEndpoint(hostname, validator);
+        verify(serviceBinder).setEndpoint(endpoint, validator);
     }
 
     @Test

--- a/core/src/test/java/com/novoda/merlin/service/HostPingerTest.java
+++ b/core/src/test/java/com/novoda/merlin/service/HostPingerTest.java
@@ -1,5 +1,7 @@
 package com.novoda.merlin.service;
 
+import com.novoda.merlin.Endpoint;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -12,7 +14,7 @@ import static org.mockito.Mockito.verify;
 
 public class HostPingerTest {
 
-    private static final String HOST_ADDRESS = "any host address";
+    private static final Endpoint ENDPOINT = Endpoint.from("any host address");
 
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
@@ -28,15 +30,15 @@ public class HostPingerTest {
 
     @Before
     public void setUp() {
-        given(pingTaskFactory.create(HOST_ADDRESS)).willReturn(pingTask);
-        hostPinger = new HostPinger(pingerCallback, HOST_ADDRESS, pingTaskFactory);
+        given(pingTaskFactory.create(ENDPOINT)).willReturn(pingTask);
+        hostPinger = new HostPinger(pingerCallback, ENDPOINT, pingTaskFactory);
     }
 
     @Test
     public void whenPinging_thenCreatesPingTask() {
         hostPinger.ping();
 
-        verify(pingTaskFactory).create(HOST_ADDRESS);
+        verify(pingTaskFactory).create(ENDPOINT);
     }
 
     @Test

--- a/core/src/test/java/com/novoda/merlin/service/MerlinServiceTest.java
+++ b/core/src/test/java/com/novoda/merlin/service/MerlinServiceTest.java
@@ -6,6 +6,7 @@ import android.content.ContextWrapper;
 import android.content.Intent;
 import android.net.ConnectivityManager;
 
+import com.novoda.merlin.Endpoint;
 import com.novoda.merlin.receiver.ConnectivityChangeEvent;
 import com.novoda.merlin.registerable.connection.ConnectListener;
 import com.novoda.merlin.registerable.disconnection.DisconnectListener;
@@ -102,7 +103,7 @@ public class MerlinServiceTest {
         MerlinService merlinService = buildStubbedMerlinService(contextWrapper, networkStatusRetriever, defaultPinger, customPinger);
 
         merlinService.onCreate();
-        merlinService.setHostname("some new host name", mock(ResponseCodeValidator.class));
+        merlinService.setHostname(Endpoint.from("some new host name"), mock(ResponseCodeValidator.class));
         merlinService.onConnectivityChanged(createConnectivityChangeEvent(IS_CONNECTED));
         verify(networkStatusRetriever).fetchWithPing(customPinger);
     }

--- a/core/src/test/java/com/novoda/merlin/service/PingTest.java
+++ b/core/src/test/java/com/novoda/merlin/service/PingTest.java
@@ -1,5 +1,6 @@
 package com.novoda.merlin.service;
 
+import com.novoda.merlin.Endpoint;
 import com.novoda.merlin.service.request.RequestException;
 
 import java.io.IOException;
@@ -18,7 +19,7 @@ import static org.mockito.Mockito.verify;
 
 public class PingTest {
 
-    private static final String HOST_ADDRESS = "any host address";
+    private static final Endpoint ENDPOINT = Endpoint.from("any host address");
 
     private static final int RESPONSE_CODE = 201;
 
@@ -35,7 +36,7 @@ public class PingTest {
     @Before
     public void setUp() {
         ping = new Ping(
-                HOST_ADDRESS,
+                ENDPOINT,
                 responseCodeFetcher,
                 responseCodeValidator
         );
@@ -43,7 +44,7 @@ public class PingTest {
 
     @Test
     public void givenSuccessfulRequest_whenSynchronouslyPinging_thenChecksResponseCodeIsValid() {
-        given(responseCodeFetcher.from(HOST_ADDRESS)).willReturn(RESPONSE_CODE);
+        given(responseCodeFetcher.from(ENDPOINT)).willReturn(RESPONSE_CODE);
 
         ping.doSynchronousPing();
 
@@ -52,7 +53,7 @@ public class PingTest {
 
     @Test
     public void givenSuccessfulRequest_whenSynchronouslyPinging_thenReturnsTrue() {
-        given(responseCodeFetcher.from(HOST_ADDRESS)).willReturn(RESPONSE_CODE);
+        given(responseCodeFetcher.from(ENDPOINT)).willReturn(RESPONSE_CODE);
         given(responseCodeValidator.isResponseCodeValid(RESPONSE_CODE)).willReturn(true);
 
         boolean isSuccess = ping.doSynchronousPing();
@@ -62,7 +63,7 @@ public class PingTest {
 
     @Test
     public void givenRequestFailsWithIOException_whenSynchronouslyPinging_thenReturnsFalse() {
-        given(responseCodeFetcher.from(HOST_ADDRESS)).willThrow(new RequestException(new IOException()));
+        given(responseCodeFetcher.from(ENDPOINT)).willThrow(new RequestException(new IOException()));
 
         boolean isSuccess = ping.doSynchronousPing();
 
@@ -71,7 +72,7 @@ public class PingTest {
 
     @Test
     public void givenRequestFailsWithRuntimeException_whenSynchronouslyPinging_thenReturnsFalse() {
-        given(responseCodeFetcher.from(HOST_ADDRESS)).willThrow(new RequestException(new RuntimeException()));
+        given(responseCodeFetcher.from(ENDPOINT)).willThrow(new RequestException(new RuntimeException()));
 
         boolean isSuccess = ping.doSynchronousPing();
 

--- a/core/src/test/java/com/novoda/merlin/service/TestDoubleMerlinServiceWithStubbedBuilders.java
+++ b/core/src/test/java/com/novoda/merlin/service/TestDoubleMerlinServiceWithStubbedBuilders.java
@@ -2,6 +2,8 @@ package com.novoda.merlin.service;
 
 import android.content.ContextWrapper;
 
+import com.novoda.merlin.Endpoint;
+
 class TestDoubleMerlinServiceWithStubbedBuilders extends MerlinService {
 
     private final ContextWrapper context;
@@ -37,7 +39,7 @@ class TestDoubleMerlinServiceWithStubbedBuilders extends MerlinService {
     }
 
     @Override
-    protected HostPinger buildHostPinger(String hostName, ResponseCodeValidator validator) {
+    protected HostPinger buildHostPinger(Endpoint endpoint, ResponseCodeValidator validator) {
         return customHostPinger;
     }
 }


### PR DESCRIPTION
## Problem
A`String` representing an Endpoint is passed all the way down through Merlin. The type `String` makes it difficult to see all usages of what is meant to be an `Endpoint` and does not enforce type safety. In future, if we wanted to add any validation around this `String` we would need to extract an additional class or swap this out.

## Solution
Replace the `String` endpoint with an `Endpoint` object to enforce type safety.

### Test(s) added
Just updated already existing tests.

### Screenshots
No UI changes.

### Paired with
Nobody.
