### PR TITLE
MER-127/Memory Leaks!

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 allprojects {
-    version = "1.0.1"
+    version = '1.0.1'
     repositories { mavenCentral() }
 }
 

--- a/core/src/main/java/com/novoda/merlin/Merlin.java
+++ b/core/src/main/java/com/novoda/merlin/Merlin.java
@@ -27,6 +27,7 @@ public class Merlin {
 
     public void unbind() {
         merlinServiceBinder.unbind();
+        registrar.clearRegistrations();
     }
 
     public void registerConnectable(Connectable connectable) {

--- a/core/src/main/java/com/novoda/merlin/registerable/Register.java
+++ b/core/src/main/java/com/novoda/merlin/registerable/Register.java
@@ -21,4 +21,7 @@ public class Register<T extends Registerable> {
         return registerables;
     }
 
+    public void clear() {
+        registerables.clear();
+    }
 }

--- a/core/src/main/java/com/novoda/merlin/registerable/Registrar.java
+++ b/core/src/main/java/com/novoda/merlin/registerable/Registrar.java
@@ -60,4 +60,9 @@ public class Registrar {
         return bindables;
     }
 
+    public void clearRegistrations() {
+        connectables.clear();
+        disconnectables.clear();
+        bindables.clear();
+    }
 }

--- a/core/src/main/java/com/novoda/merlin/service/LocalBinderDependencyMissingException.java
+++ b/core/src/main/java/com/novoda/merlin/service/LocalBinderDependencyMissingException.java
@@ -1,0 +1,22 @@
+package com.novoda.merlin.service;
+
+import java.util.Locale;
+
+class LocalBinderDependencyMissingException extends IllegalStateException {
+
+    private static final String DEPENDENCY_ASSERT_FORMAT = "%s must be bound to %s.";
+
+    static LocalBinderDependencyMissingException missing(Class dependency) {
+        String message = String.format(
+                Locale.ENGLISH,
+                DEPENDENCY_ASSERT_FORMAT,
+                dependency,
+                MerlinService.class
+        );
+        return new LocalBinderDependencyMissingException(message);
+    }
+
+    private LocalBinderDependencyMissingException(String message) {
+        super(message);
+    }
+}

--- a/core/src/main/java/com/novoda/merlin/service/MerlinService.java
+++ b/core/src/main/java/com/novoda/merlin/service/MerlinService.java
@@ -30,9 +30,16 @@ public class MerlinService extends Service {
     @Override
     public boolean onUnbind(Intent intent) {
         isBound = false;
-        connectivityChangesRegister.unregister();
-        connectivityChangesForwarder = null;
-        connectivityChangesRegister = null;
+        if (connectivityChangesRegister != null) {
+            connectivityChangesRegister.unregister();
+            connectivityChangesRegister = null;
+
+        }
+
+        if (connectivityChangesForwarder != null) {
+            connectivityChangesForwarder = null;
+        }
+
         binder = null;
         return super.onUnbind(intent);
     }
@@ -68,15 +75,18 @@ public class MerlinService extends Service {
         }
 
         void onBindComplete() {
+            assertDependenciesBound();
+            MerlinService.this.start();
+        }
+
+        private void assertDependenciesBound() {
             if (MerlinService.this.connectivityChangesRegister == null) {
-                throw new IllegalStateException("setConnectivityChangesRegister must be called.");
+                throw LocalBinderDependencyMissingException.missing(ConnectivityChangesRegister.class);
             }
 
             if (MerlinService.this.connectivityChangesForwarder == null) {
-                throw new IllegalStateException("setConnectivityChangesForwarder must be called.");
+                throw LocalBinderDependencyMissingException.missing(ConnectivityChangesForwarder.class);
             }
-
-            MerlinService.this.start();
         }
     }
 

--- a/core/src/main/java/com/novoda/merlin/service/MerlinService.java
+++ b/core/src/main/java/com/novoda/merlin/service/MerlinService.java
@@ -12,7 +12,7 @@ public class MerlinService extends Service {
 
     private static boolean isBound;
 
-    private final IBinder binder = new LocalBinder();
+    private IBinder binder = new LocalBinder();
 
     private ConnectivityChangesRegister connectivityChangesRegister;
     private ConnectivityChangesForwarder connectivityChangesForwarder;
@@ -31,6 +31,9 @@ public class MerlinService extends Service {
     public boolean onUnbind(Intent intent) {
         isBound = false;
         connectivityChangesRegister.unregister();
+        connectivityChangesForwarder = null;
+        connectivityChangesRegister = null;
+        binder = null;
         return super.onUnbind(intent);
     }
 

--- a/core/src/main/java/com/novoda/merlin/service/MerlinService.java
+++ b/core/src/main/java/com/novoda/merlin/service/MerlinService.java
@@ -59,15 +59,25 @@ public class MerlinService extends Service {
             return MerlinService.this.connectivityChangesListener;
         }
 
-        void setConnectivityChangesRegister(ConnectivityChangesRegister connectivityChangesRegister) {
+        LocalBinder setConnectivityChangesRegister(ConnectivityChangesRegister connectivityChangesRegister) {
             MerlinService.this.connectivityChangesRegister = connectivityChangesRegister;
+            return this;
         }
 
-        void setConnectivityChangesForwarder(ConnectivityChangesForwarder connectivityChangesForwarder) {
+        LocalBinder setConnectivityChangesForwarder(ConnectivityChangesForwarder connectivityChangesForwarder) {
             MerlinService.this.connectivityChangesForwarder = connectivityChangesForwarder;
+            return this;
         }
 
         void onBindComplete() {
+            if (MerlinService.this.connectivityChangesRegister == null) {
+                throw new IllegalStateException("setConnectivityChangesRegister must be called.");
+            }
+
+            if (MerlinService.this.connectivityChangesForwarder == null) {
+                throw new IllegalStateException("setConnectivityChangesForwarder must be called.");
+            }
+
             MerlinService.this.start();
         }
     }

--- a/core/src/main/java/com/novoda/merlin/service/MerlinService.java
+++ b/core/src/main/java/com/novoda/merlin/service/MerlinService.java
@@ -45,8 +45,19 @@ public class MerlinService extends Service {
     }
 
     private void start() {
+        assertDependenciesBound();
         connectivityChangesForwarder.forwardInitialNetworkStatus();
         connectivityChangesRegister.register(connectivityChangesListener);
+    }
+
+    private void assertDependenciesBound() {
+        if (MerlinService.this.connectivityChangesRegister == null) {
+            throw MerlinServiceDependencyMissingException.missing(ConnectivityChangesRegister.class);
+        }
+
+        if (MerlinService.this.connectivityChangesForwarder == null) {
+            throw MerlinServiceDependencyMissingException.missing(ConnectivityChangesForwarder.class);
+        }
     }
 
     private final ConnectivityChangesListener connectivityChangesListener = new ConnectivityChangesListener() {
@@ -75,18 +86,7 @@ public class MerlinService extends Service {
         }
 
         void onBindComplete() {
-            assertDependenciesBound();
             MerlinService.this.start();
-        }
-
-        private void assertDependenciesBound() {
-            if (MerlinService.this.connectivityChangesRegister == null) {
-                throw LocalBinderDependencyMissingException.missing(ConnectivityChangesRegister.class);
-            }
-
-            if (MerlinService.this.connectivityChangesForwarder == null) {
-                throw LocalBinderDependencyMissingException.missing(ConnectivityChangesForwarder.class);
-            }
         }
     }
 

--- a/core/src/main/java/com/novoda/merlin/service/MerlinService.java
+++ b/core/src/main/java/com/novoda/merlin/service/MerlinService.java
@@ -59,14 +59,12 @@ public class MerlinService extends Service {
             return MerlinService.this.connectivityChangesListener;
         }
 
-        LocalBinder setConnectivityChangesRegister(ConnectivityChangesRegister connectivityChangesRegister) {
+        void setConnectivityChangesRegister(ConnectivityChangesRegister connectivityChangesRegister) {
             MerlinService.this.connectivityChangesRegister = connectivityChangesRegister;
-            return this;
         }
 
-        LocalBinder setConnectivityChangesForwarder(ConnectivityChangesForwarder connectivityChangesForwarder) {
+        void setConnectivityChangesForwarder(ConnectivityChangesForwarder connectivityChangesForwarder) {
             MerlinService.this.connectivityChangesForwarder = connectivityChangesForwarder;
-            return this;
         }
 
         void onBindComplete() {

--- a/core/src/main/java/com/novoda/merlin/service/MerlinServiceBinder.java
+++ b/core/src/main/java/com/novoda/merlin/service/MerlinServiceBinder.java
@@ -87,9 +87,9 @@ public class MerlinServiceBinder {
                     endpointPinger
             );
 
-            merlinServiceBinder.setConnectivityChangesRegister(connectivityChangesRegister)
-                    .setConnectivityChangesForwarder(connectivityChangesForwarder)
-                    .onBindComplete();
+            merlinServiceBinder.setConnectivityChangesRegister(connectivityChangesRegister);
+            merlinServiceBinder.setConnectivityChangesForwarder(connectivityChangesForwarder);
+            merlinServiceBinder.onBindComplete();
         }
 
         @Override

--- a/core/src/main/java/com/novoda/merlin/service/MerlinServiceBinder.java
+++ b/core/src/main/java/com/novoda/merlin/service/MerlinServiceBinder.java
@@ -48,6 +48,7 @@ public class MerlinServiceBinder {
     public void unbind() {
         if (MerlinService.isBound()) {
             context.unbindService(merlinServiceConnection);
+            context.stopService(new Intent(context, MerlinService.class));
             merlinServiceConnection = null;
         }
     }

--- a/core/src/main/java/com/novoda/merlin/service/MerlinServiceBinder.java
+++ b/core/src/main/java/com/novoda/merlin/service/MerlinServiceBinder.java
@@ -87,9 +87,9 @@ public class MerlinServiceBinder {
                     endpointPinger
             );
 
-            merlinServiceBinder.setConnectivityChangesRegister(connectivityChangesRegister);
-            merlinServiceBinder.setConnectivityChangesForwarder(connectivityChangesForwarder);
-            merlinServiceBinder.onBindComplete();
+            merlinServiceBinder.setConnectivityChangesRegister(connectivityChangesRegister)
+                    .setConnectivityChangesForwarder(connectivityChangesForwarder)
+                    .onBindComplete();
         }
 
         @Override

--- a/core/src/main/java/com/novoda/merlin/service/MerlinServiceDependencyMissingException.java
+++ b/core/src/main/java/com/novoda/merlin/service/MerlinServiceDependencyMissingException.java
@@ -2,21 +2,21 @@ package com.novoda.merlin.service;
 
 import java.util.Locale;
 
-class LocalBinderDependencyMissingException extends IllegalStateException {
+class MerlinServiceDependencyMissingException extends IllegalStateException {
 
     private static final String DEPENDENCY_ASSERT_FORMAT = "%s must be bound to %s.";
 
-    static LocalBinderDependencyMissingException missing(Class dependency) {
+    static MerlinServiceDependencyMissingException missing(Class dependency) {
         String message = String.format(
                 Locale.ENGLISH,
                 DEPENDENCY_ASSERT_FORMAT,
                 dependency,
                 MerlinService.class
         );
-        return new LocalBinderDependencyMissingException(message);
+        return new MerlinServiceDependencyMissingException(message);
     }
 
-    private LocalBinderDependencyMissingException(String message) {
+    private MerlinServiceDependencyMissingException(String message) {
         super(message);
     }
 }

--- a/core/src/test/java/com/novoda/merlin/MerlinTest.java
+++ b/core/src/test/java/com/novoda/merlin/MerlinTest.java
@@ -65,6 +65,13 @@ public class MerlinTest {
     }
 
     @Test
+    public void whenUnbinding_thenClearsRegistrations() {
+        merlin.unbind();
+
+        verify(registrar).clearRegistrations();
+    }
+
+    @Test
     public void whenRegisteringConnectable_thenRegistersConnectable() {
         Connectable connectable = mock(Connectable.class);
 

--- a/core/src/test/java/com/novoda/merlin/registerable/RegistrarTest.java
+++ b/core/src/test/java/com/novoda/merlin/registerable/RegistrarTest.java
@@ -21,21 +21,21 @@ public class RegistrarTest {
     public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Mock
-    private Register<Connectable> connector;
+    private Register<Connectable> connectables;
     @Mock
-    private Register<Disconnectable> disconnector;
+    private Register<Disconnectable> disconnectables;
     @Mock
-    private Register<Bindable> binder;
+    private Register<Bindable> bindables;
 
     private Registrar registrar;
 
     @Before
     public void setUp() {
-        registrar = new Registrar(connector, disconnector, binder);
+        registrar = new Registrar(connectables, disconnectables, bindables);
     }
 
     @Test(expected = MerlinException.class)
-    public void givenMissingConnector_whenRegisteringConnectable_thenThrowsDeveloperException() {
+    public void givenMissingRegister_whenRegisteringConnectable_thenThrowsDeveloperException() {
         registrar = new Registrar(null, null, null);
 
         Connectable connectable = mock(Connectable.class);
@@ -43,7 +43,7 @@ public class RegistrarTest {
     }
 
     @Test(expected = MerlinException.class)
-    public void givenMissingDisconnector_thenRegisteringDisconnectable_thenThrowsDeveloperException() {
+    public void givenMissingRegister_thenRegisteringDisconnectable_thenThrowsDeveloperException() {
         registrar = new Registrar(null, null, null);
 
         Disconnectable disconnectable = mock(Disconnectable.class);
@@ -51,7 +51,7 @@ public class RegistrarTest {
     }
 
     @Test(expected = MerlinException.class)
-    public void givenMissingBinder_whenRegisteringBindable_thenThrowsDeveloperException() {
+    public void givenMissingRegister_whenRegisteringBindable_thenThrowsDeveloperException() {
         registrar = new Registrar(null, null, null);
 
         Bindable bindable = mock(Bindable.class);
@@ -59,30 +59,39 @@ public class RegistrarTest {
     }
 
     @Test
-    public void givenConnector_whenRegisteringConnectable_thenRegistersConnectableWithConnector() {
+    public void givenRegister_whenRegisteringConnectable_thenRegistersConnectableWithConnector() {
         Connectable connectable = mock(Connectable.class);
 
         registrar.registerConnectable(connectable);
 
-        verify(connector).register(connectable);
+        verify(connectables).register(connectable);
     }
 
     @Test
-    public void givenDisconnector_whenRegisteringDisconnectable_thenRegistersDisconnectableWithDisconnector() {
+    public void givenRegister_whenRegisteringDisconnectable_thenRegistersDisconnectableWithDisconnector() {
         Disconnectable disconnectable = mock(Disconnectable.class);
 
         registrar.registerDisconnectable(disconnectable);
 
-        verify(disconnector).register(disconnectable);
+        verify(this.disconnectables).register(disconnectable);
     }
 
     @Test
-    public void givenBinder_whenRegisteringBindable_thenRegistersBindableWithBinder() {
+    public void givenRegister_whenRegisteringBindable_thenRegistersBindableWithBinder() {
         Bindable bindable = mock(Bindable.class);
 
         registrar.registerBindable(bindable);
 
-        verify(binder).register(bindable);
+        verify(bindables).register(bindable);
+    }
+
+    @Test
+    public void whenClearingRegistrations_thenDelegatesClearingToRegisters() {
+        registrar.clearRegistrations();
+
+        verify(connectables).clear();
+        verify(disconnectables).clear();
+        verify(bindables).clear();
     }
 
 }

--- a/core/src/test/java/com/novoda/merlin/service/LocalBinderDependencyMissingExceptionMatcher.java
+++ b/core/src/test/java/com/novoda/merlin/service/LocalBinderDependencyMissingExceptionMatcher.java
@@ -1,0 +1,71 @@
+package com.novoda.merlin.service;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+
+class LocalBinderDependencyMissingExceptionMatcher extends BaseMatcher<LocalBinderDependencyMissingException> {
+
+    private String expectedMessage;
+    private Throwable expectedCause;
+
+    public static LocalBinderDependencyMissingExceptionMatcher from(Class expectedDependency) {
+        LocalBinderDependencyMissingException expectedException = LocalBinderDependencyMissingException.missing(expectedDependency);
+        return new LocalBinderDependencyMissingExceptionMatcher(expectedException);
+    }
+
+    private LocalBinderDependencyMissingExceptionMatcher(LocalBinderDependencyMissingException exception) {
+        this.expectedMessage = exception.getMessage();
+        this.expectedCause = exception.getCause();
+    }
+
+    @Override
+    public boolean matches(Object o) {
+        LocalBinderDependencyMissingException exception = (LocalBinderDependencyMissingException) o;
+        return messageMatches(exception) && causeMatches(exception);
+    }
+
+    private boolean messageMatches(LocalBinderDependencyMissingException exception) {
+        return expectedMessage.equals(exception.getMessage());
+    }
+
+    private boolean causeMatches(LocalBinderDependencyMissingException exception) {
+        if (expectedCause == null) {
+            return exception.getCause() == null;
+        } else {
+            return expectedCause.equals(exception.getCause());
+        }
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        String message = String.format(
+                "%s: %s, cause: %s",
+                LocalBinderDependencyMissingException.class.getSimpleName(),
+                expectedMessage,
+                expectedCause
+        );
+
+        description.appendText(message);
+    }
+
+    @Override
+    public void describeMismatch(Object item, Description description) {
+        if (item instanceof Throwable) {
+            Throwable throwable = (Throwable) item;
+            String message = String.format(
+                    "was: %s: %s, cause: %s",
+                    LocalBinderDependencyMissingException.class.getSimpleName(),
+                    throwable.getMessage(),
+                    throwable.getCause()
+            );
+
+            description.appendText(message);
+        } else {
+            super.describeMismatch(item, description);
+        }
+    }
+
+}
+
+
+

--- a/core/src/test/java/com/novoda/merlin/service/MerlinServiceDependencyMissingExceptionMatcher.java
+++ b/core/src/test/java/com/novoda/merlin/service/MerlinServiceDependencyMissingExceptionMatcher.java
@@ -3,32 +3,32 @@ package com.novoda.merlin.service;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 
-class LocalBinderDependencyMissingExceptionMatcher extends BaseMatcher<LocalBinderDependencyMissingException> {
+class MerlinServiceDependencyMissingExceptionMatcher extends BaseMatcher<MerlinServiceDependencyMissingException> {
 
     private String expectedMessage;
     private Throwable expectedCause;
 
-    public static LocalBinderDependencyMissingExceptionMatcher from(Class expectedDependency) {
-        LocalBinderDependencyMissingException expectedException = LocalBinderDependencyMissingException.missing(expectedDependency);
-        return new LocalBinderDependencyMissingExceptionMatcher(expectedException);
+    public static MerlinServiceDependencyMissingExceptionMatcher from(Class expectedDependency) {
+        MerlinServiceDependencyMissingException expectedException = MerlinServiceDependencyMissingException.missing(expectedDependency);
+        return new MerlinServiceDependencyMissingExceptionMatcher(expectedException);
     }
 
-    private LocalBinderDependencyMissingExceptionMatcher(LocalBinderDependencyMissingException exception) {
+    private MerlinServiceDependencyMissingExceptionMatcher(MerlinServiceDependencyMissingException exception) {
         this.expectedMessage = exception.getMessage();
         this.expectedCause = exception.getCause();
     }
 
     @Override
     public boolean matches(Object o) {
-        LocalBinderDependencyMissingException exception = (LocalBinderDependencyMissingException) o;
+        MerlinServiceDependencyMissingException exception = (MerlinServiceDependencyMissingException) o;
         return messageMatches(exception) && causeMatches(exception);
     }
 
-    private boolean messageMatches(LocalBinderDependencyMissingException exception) {
+    private boolean messageMatches(MerlinServiceDependencyMissingException exception) {
         return expectedMessage.equals(exception.getMessage());
     }
 
-    private boolean causeMatches(LocalBinderDependencyMissingException exception) {
+    private boolean causeMatches(MerlinServiceDependencyMissingException exception) {
         if (expectedCause == null) {
             return exception.getCause() == null;
         } else {
@@ -40,7 +40,7 @@ class LocalBinderDependencyMissingExceptionMatcher extends BaseMatcher<LocalBind
     public void describeTo(Description description) {
         String message = String.format(
                 "%s: %s, cause: %s",
-                LocalBinderDependencyMissingException.class.getSimpleName(),
+                MerlinServiceDependencyMissingException.class.getSimpleName(),
                 expectedMessage,
                 expectedCause
         );
@@ -54,7 +54,7 @@ class LocalBinderDependencyMissingExceptionMatcher extends BaseMatcher<LocalBind
             Throwable throwable = (Throwable) item;
             String message = String.format(
                     "was: %s: %s, cause: %s",
-                    LocalBinderDependencyMissingException.class.getSimpleName(),
+                    MerlinServiceDependencyMissingException.class.getSimpleName(),
                     throwable.getMessage(),
                     throwable.getCause()
             );

--- a/core/src/test/java/com/novoda/merlin/service/MerlinServiceTest.java
+++ b/core/src/test/java/com/novoda/merlin/service/MerlinServiceTest.java
@@ -8,6 +8,7 @@ import com.novoda.merlin.receiver.ConnectivityChangesRegister;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
@@ -25,6 +26,8 @@ public class MerlinServiceTest {
 
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Mock
     private Intent intent;
@@ -92,6 +95,26 @@ public class MerlinServiceTest {
         connectivityChangesListener.onConnectivityChanged(ANY_CONNECTIVITY_CHANGE_EVENT);
 
         verify(connectivityChangesForwarder).forward(ANY_CONNECTIVITY_CHANGE_EVENT);
+    }
+
+    @Test
+    public void givenConnectivityChangesRegisterIsNotBound_whenBindCompletes_thenThrowsException() {
+        thrown.expect(LocalBinderDependencyMissingExceptionMatcher.from(ConnectivityChangesRegister.class));
+
+        MerlinService.LocalBinder binder = (MerlinService.LocalBinder) merlinService.onBind(intent);
+        binder.setConnectivityChangesForwarder(connectivityChangesForwarder);
+
+        binder.onBindComplete();
+    }
+
+    @Test
+    public void givenConnectivityChangesForwarderIsNotBound_whenBindCompletes_thenThrowsException() {
+        thrown.expect(LocalBinderDependencyMissingExceptionMatcher.from(ConnectivityChangesForwarder.class));
+
+        MerlinService.LocalBinder binder = (MerlinService.LocalBinder) merlinService.onBind(intent);
+        binder.setConnectivityChangesRegister(connectivityChangesRegister);
+
+        binder.onBindComplete();
     }
 
     private MerlinService.LocalBinder givenBoundMerlinService() {

--- a/core/src/test/java/com/novoda/merlin/service/MerlinServiceTest.java
+++ b/core/src/test/java/com/novoda/merlin/service/MerlinServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.junit.MockitoRule;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class MerlinServiceTest {
 
@@ -98,23 +99,29 @@ public class MerlinServiceTest {
     }
 
     @Test
-    public void givenConnectivityChangesRegisterIsNotBound_whenBindCompletes_thenThrowsException() {
-        thrown.expect(LocalBinderDependencyMissingExceptionMatcher.from(ConnectivityChangesRegister.class));
+    public void givenConnectivityChangesRegisterIsNotBound_whenBindCompletes_thenThrowsException_andStopsWorkOnService() {
+        thrown.expect(MerlinServiceDependencyMissingExceptionMatcher.from(ConnectivityChangesRegister.class));
 
         MerlinService.LocalBinder binder = (MerlinService.LocalBinder) merlinService.onBind(intent);
         binder.setConnectivityChangesForwarder(connectivityChangesForwarder);
 
         binder.onBindComplete();
+
+        verifyZeroInteractions(connectivityChangesRegister);
+        verifyZeroInteractions(connectivityChangesForwarder);
     }
 
     @Test
-    public void givenConnectivityChangesForwarderIsNotBound_whenBindCompletes_thenThrowsException() {
-        thrown.expect(LocalBinderDependencyMissingExceptionMatcher.from(ConnectivityChangesForwarder.class));
+    public void givenConnectivityChangesForwarderIsNotBound_whenBindCompletes_thenThrowsException_andStopsWorkOnService() {
+        thrown.expect(MerlinServiceDependencyMissingExceptionMatcher.from(ConnectivityChangesForwarder.class));
 
         MerlinService.LocalBinder binder = (MerlinService.LocalBinder) merlinService.onBind(intent);
         binder.setConnectivityChangesRegister(connectivityChangesRegister);
 
         binder.onBindComplete();
+
+        verifyZeroInteractions(connectivityChangesRegister);
+        verifyZeroInteractions(connectivityChangesForwarder);
     }
 
     private MerlinService.LocalBinder givenBoundMerlinService() {

--- a/demo/src/main/java/com/novoda/merlin/demo/connectivity/display/MerlinSnackbar.java
+++ b/demo/src/main/java/com/novoda/merlin/demo/connectivity/display/MerlinSnackbar.java
@@ -1,19 +1,18 @@
 package com.novoda.merlin.demo.connectivity.display;
 
 import android.content.res.Resources;
+import android.support.annotation.IntegerRes;
 import android.support.annotation.StringRes;
 import android.support.design.widget.Snackbar;
 import android.view.View;
-
-import com.novoda.merlin.demo.R;
 
 class MerlinSnackbar {
 
     private static final String EMPTY_MESSAGE = "";
     private final Snackbar snackbar;
 
-    static MerlinSnackbar withDuration(Resources resources, View attachTo) {
-        int duration = resources.getInteger(R.integer.snackbar_duration);
+    static MerlinSnackbar withDuration(Resources resources, View attachTo, @IntegerRes int durationResource) {
+        int duration = resources.getInteger(durationResource);
         Snackbar snackbar = Snackbar.make(attachTo, EMPTY_MESSAGE, duration);
         return new MerlinSnackbar(snackbar);
     }
@@ -23,7 +22,7 @@ class MerlinSnackbar {
     }
 
     MerlinSnackbar withTheme(Themer themer) {
-        themer.theme(snackbar.getContext().getResources(), snackbar);
+        themer.applyTheme(snackbar.getContext().getResources(), snackbar);
         return this;
     }
 

--- a/demo/src/main/java/com/novoda/merlin/demo/connectivity/display/MerlinSnackbar.java
+++ b/demo/src/main/java/com/novoda/merlin/demo/connectivity/display/MerlinSnackbar.java
@@ -2,6 +2,7 @@ package com.novoda.merlin.demo.connectivity.display;
 
 import android.content.res.Resources;
 import android.support.annotation.IntegerRes;
+import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
 import android.support.design.widget.Snackbar;
 import android.view.View;
@@ -11,6 +12,7 @@ class MerlinSnackbar {
     private static final String EMPTY_MESSAGE = "";
     private final Snackbar snackbar;
 
+    @NonNull
     static MerlinSnackbar withDuration(Resources resources, View attachTo, @IntegerRes int durationResource) {
         int duration = resources.getInteger(durationResource);
         Snackbar snackbar = Snackbar.make(attachTo, EMPTY_MESSAGE, duration);
@@ -36,10 +38,11 @@ class MerlinSnackbar {
         return this;
     }
 
-    void show() {
+    MerlinSnackbar show() {
         if (!snackbar.isShown()) {
             snackbar.show();
         }
+        return this;
     }
 
     void dismiss() {

--- a/demo/src/main/java/com/novoda/merlin/demo/connectivity/display/NegativeThemer.java
+++ b/demo/src/main/java/com/novoda/merlin/demo/connectivity/display/NegativeThemer.java
@@ -10,7 +10,7 @@ import com.novoda.merlin.demo.R;
 class NegativeThemer implements Themer {
 
     @Override
-    public void theme(Resources resources, Snackbar snackbar) {
+    public void applyTheme(Resources resources, Snackbar snackbar) {
         Snackbar.SnackbarLayout snackbarView = (Snackbar.SnackbarLayout) snackbar.getView();
 
         TextView messageView = (TextView) snackbarView.findViewById(R.id.snackbar_text);

--- a/demo/src/main/java/com/novoda/merlin/demo/connectivity/display/NetworkStatusDisplayer.java
+++ b/demo/src/main/java/com/novoda/merlin/demo/connectivity/display/NetworkStatusDisplayer.java
@@ -1,6 +1,7 @@
 package com.novoda.merlin.demo.connectivity.display;
 
 import android.content.res.Resources;
+import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.view.View;
 
@@ -12,6 +13,7 @@ public class NetworkStatusDisplayer {
     private final Resources resources;
     private final MerlinsBeard merlinsBeard;
 
+    @Nullable
     private MerlinSnackbar snackbar;
 
     public NetworkStatusDisplayer(Resources resources, MerlinsBeard merlinsBeard) {
@@ -20,31 +22,42 @@ public class NetworkStatusDisplayer {
     }
 
     public void displayPositiveMessage(@StringRes int messageResource, View attachTo) {
-        snackbar = MerlinSnackbar.withDuration(resources, attachTo, R.integer.snackbar_duration);
-        snackbar.withText(messageResource)
+        snackbar = MerlinSnackbar.withDuration(resources, attachTo, R.integer.snackbar_duration)
+                .withText(messageResource)
                 .withTheme(new PositiveThemer())
                 .show();
     }
 
     public void displayNegativeMessage(@StringRes int messageResource, View attachTo) {
-        snackbar = MerlinSnackbar.withDuration(resources, attachTo, R.integer.snackbar_duration);
-        snackbar.withText(messageResource)
+        snackbar = MerlinSnackbar.withDuration(resources, attachTo, R.integer.snackbar_duration)
+                .withText(messageResource)
                 .withTheme(new NegativeThemer())
                 .show();
     }
 
     public void displayNetworkSubtype(View attachTo) {
         String subtype = merlinsBeard.getMobileNetworkSubtypeName();
-        snackbar = MerlinSnackbar.withDuration(resources, attachTo, R.integer.snackbar_duration);
+        snackbar = MerlinSnackbar.withDuration(resources, attachTo, R.integer.snackbar_duration)
+                .withText(subtypeMessageFrom(subtype))
+                .withTheme(subtypeThemerFrom(subtype))
+                .show();
 
+    }
+
+    @StringRes
+    private int subtypeMessageFrom(String subtype) {
         if (subtypeAbsent(subtype)) {
-            snackbar.withText(R.string.subtype_not_available)
-                    .withTheme(new NegativeThemer())
-                    .show();
+            return R.string.subtype_not_available;
         } else {
-            snackbar.withText(resources.getString(R.string.subtype_value, subtype))
-                    .withTheme(new PositiveThemer())
-                    .show();
+            return R.string.subtype_value;
+        }
+    }
+
+    private Themer subtypeThemerFrom(String subtype) {
+        if (subtypeAbsent(subtype)) {
+            return new NegativeThemer();
+        } else {
+            return new PositiveThemer();
         }
     }
 

--- a/demo/src/main/java/com/novoda/merlin/demo/connectivity/display/NetworkStatusDisplayer.java
+++ b/demo/src/main/java/com/novoda/merlin/demo/connectivity/display/NetworkStatusDisplayer.java
@@ -4,34 +4,38 @@ import android.content.res.Resources;
 import android.support.annotation.StringRes;
 import android.view.View;
 
+import com.novoda.merlin.MerlinsBeard;
 import com.novoda.merlin.demo.R;
 
 public class NetworkStatusDisplayer {
 
     private final Resources resources;
+    private final MerlinsBeard merlinsBeard;
 
     private MerlinSnackbar snackbar;
 
-    public NetworkStatusDisplayer(Resources resources) {
+    public NetworkStatusDisplayer(Resources resources, MerlinsBeard merlinsBeard) {
         this.resources = resources;
+        this.merlinsBeard = merlinsBeard;
     }
 
     public void displayPositiveMessage(@StringRes int messageResource, View attachTo) {
-        snackbar = MerlinSnackbar.withDuration(resources, attachTo);
+        snackbar = MerlinSnackbar.withDuration(resources, attachTo, R.integer.snackbar_duration);
         snackbar.withText(messageResource)
                 .withTheme(new PositiveThemer())
                 .show();
     }
 
     public void displayNegativeMessage(@StringRes int messageResource, View attachTo) {
-        snackbar = MerlinSnackbar.withDuration(resources, attachTo);
+        snackbar = MerlinSnackbar.withDuration(resources, attachTo, R.integer.snackbar_duration);
         snackbar.withText(messageResource)
                 .withTheme(new NegativeThemer())
                 .show();
     }
 
-    public void displayNetworkSubtype(String subtype, View attachTo) {
-        snackbar = MerlinSnackbar.withDuration(resources, attachTo);
+    public void displayNetworkSubtype(View attachTo) {
+        String subtype = merlinsBeard.getMobileNetworkSubtypeName();
+        snackbar = MerlinSnackbar.withDuration(resources, attachTo, R.integer.snackbar_duration);
 
         if (subtypeAbsent(subtype)) {
             snackbar.withText(R.string.subtype_not_available)
@@ -49,10 +53,11 @@ public class NetworkStatusDisplayer {
     }
 
     public void reset() {
-        if (snackbar != null) {
-            snackbar.dismiss();
-            snackbar = null;
+        if (snackbar == null) {
+            return;
         }
+        snackbar.dismiss();
+        snackbar = null;
     }
 
 }

--- a/demo/src/main/java/com/novoda/merlin/demo/connectivity/display/PositiveThemer.java
+++ b/demo/src/main/java/com/novoda/merlin/demo/connectivity/display/PositiveThemer.java
@@ -10,7 +10,7 @@ import com.novoda.merlin.demo.R;
 class PositiveThemer implements Themer {
 
     @Override
-    public void theme(Resources resources, Snackbar snackbar) {
+    public void applyTheme(Resources resources, Snackbar snackbar) {
         Snackbar.SnackbarLayout snackbarView = (Snackbar.SnackbarLayout) snackbar.getView();
 
         TextView messageView = (TextView) snackbarView.findViewById(R.id.snackbar_text);

--- a/demo/src/main/java/com/novoda/merlin/demo/connectivity/display/Themer.java
+++ b/demo/src/main/java/com/novoda/merlin/demo/connectivity/display/Themer.java
@@ -5,6 +5,6 @@ import android.support.design.widget.Snackbar;
 
 interface Themer {
 
-    void theme(Resources resources, Snackbar snackbar);
+    void applyTheme(Resources resources, Snackbar snackbar);
 
 }

--- a/demo/src/main/java/com/novoda/merlin/demo/presentation/DemoActivity.java
+++ b/demo/src/main/java/com/novoda/merlin/demo/presentation/DemoActivity.java
@@ -25,8 +25,8 @@ public class DemoActivity extends MerlinActivity implements Connectable, Disconn
         setContentView(R.layout.main);
 
         viewToAttachDisplayerTo = findViewById(R.id.displayerAttachableView);
-        networkStatusDisplayer = new NetworkStatusDisplayer(getResources());
         merlinsBeard = MerlinsBeard.from(this);
+        networkStatusDisplayer = new NetworkStatusDisplayer(getResources(), merlinsBeard);
 
         findViewById(R.id.current_status).setOnClickListener(networkStatusOnClick);
         findViewById(R.id.wifi_connected).setOnClickListener(wifiConnectedOnClick);
@@ -73,7 +73,7 @@ public class DemoActivity extends MerlinActivity implements Connectable, Disconn
 
         @Override
         public void onClick(View view) {
-            networkStatusDisplayer.displayNetworkSubtype(merlinsBeard.getMobileNetworkSubtypeName(), viewToAttachDisplayerTo);
+            networkStatusDisplayer.displayNetworkSubtype(viewToAttachDisplayerTo);
         }
     };
 

--- a/demo/src/main/java/com/novoda/merlin/demo/presentation/DemoActivity.java
+++ b/demo/src/main/java/com/novoda/merlin/demo/presentation/DemoActivity.java
@@ -83,7 +83,7 @@ public class DemoActivity extends MerlinActivity implements Connectable, Disconn
                 .withConnectableCallbacks()
                 .withDisconnectableCallbacks()
                 .withBindableCallbacks()
-                .build(getApplicationContext());
+                .build(this);
     }
 
     @Override

--- a/demo/src/main/java/com/novoda/merlin/demo/presentation/DemoActivity.java
+++ b/demo/src/main/java/com/novoda/merlin/demo/presentation/DemoActivity.java
@@ -83,7 +83,7 @@ public class DemoActivity extends MerlinActivity implements Connectable, Disconn
                 .withConnectableCallbacks()
                 .withDisconnectableCallbacks()
                 .withBindableCallbacks()
-                .build(this);
+                .build(getApplicationContext());
     }
 
     @Override

--- a/demo/src/main/java/com/novoda/merlin/demo/presentation/RxJava2DemoActivity.java
+++ b/demo/src/main/java/com/novoda/merlin/demo/presentation/RxJava2DemoActivity.java
@@ -83,7 +83,7 @@ public class RxJava2DemoActivity extends Activity {
     @Override
     protected void onResume() {
         super.onResume();
-        Disposable merlinDisposable = MerlinFlowable.from(getApplicationContext())
+        Disposable merlinDisposable = MerlinFlowable.from(this)
                 .distinctUntilChanged()
                 .subscribe(new NetworkConsumer(networkStatusDisplayer, viewToAttachDisplayerTo));
         disposables.add(merlinDisposable);

--- a/demo/src/main/java/com/novoda/merlin/demo/presentation/RxJava2DemoActivity.java
+++ b/demo/src/main/java/com/novoda/merlin/demo/presentation/RxJava2DemoActivity.java
@@ -83,7 +83,7 @@ public class RxJava2DemoActivity extends Activity {
     @Override
     protected void onResume() {
         super.onResume();
-        Disposable merlinDisposable = MerlinFlowable.from(this)
+        Disposable merlinDisposable = MerlinFlowable.from(getApplicationContext())
                 .distinctUntilChanged()
                 .subscribe(new NetworkConsumer(networkStatusDisplayer, viewToAttachDisplayerTo));
         disposables.add(merlinDisposable);

--- a/demo/src/main/java/com/novoda/merlin/demo/presentation/RxJava2DemoActivity.java
+++ b/demo/src/main/java/com/novoda/merlin/demo/presentation/RxJava2DemoActivity.java
@@ -27,7 +27,7 @@ public class RxJava2DemoActivity extends Activity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.main);
         viewToAttachDisplayerTo = findViewById(R.id.displayerAttachableView);
-        networkStatusDisplayer = new NetworkStatusDisplayer(getResources());
+        networkStatusDisplayer = new NetworkStatusDisplayer(getResources(), merlinsBeard);
         merlinsBeard = MerlinsBeard.from(this);
         disposables = new CompositeDisposable();
 
@@ -76,7 +76,7 @@ public class RxJava2DemoActivity extends Activity {
 
         @Override
         public void onClick(View view) {
-            networkStatusDisplayer.displayNetworkSubtype(merlinsBeard.getMobileNetworkSubtypeName(), viewToAttachDisplayerTo);
+            networkStatusDisplayer.displayNetworkSubtype(viewToAttachDisplayerTo);
         }
     };
 

--- a/demo/src/main/java/com/novoda/merlin/demo/presentation/RxJavaDemoActivity.java
+++ b/demo/src/main/java/com/novoda/merlin/demo/presentation/RxJavaDemoActivity.java
@@ -82,7 +82,7 @@ public class RxJavaDemoActivity extends Activity {
     @Override
     protected void onResume() {
         super.onResume();
-        Subscription merlinSubscription = MerlinObservable.from(this)
+        Subscription merlinSubscription = MerlinObservable.from(getApplicationContext())
                 .distinctUntilChanged()
                 .subscribe(new NetworkAction(networkStatusDisplayer, viewToAttachDisplayerTo));
         subscriptions.add(merlinSubscription);

--- a/demo/src/main/java/com/novoda/merlin/demo/presentation/RxJavaDemoActivity.java
+++ b/demo/src/main/java/com/novoda/merlin/demo/presentation/RxJavaDemoActivity.java
@@ -82,7 +82,7 @@ public class RxJavaDemoActivity extends Activity {
     @Override
     protected void onResume() {
         super.onResume();
-        Subscription merlinSubscription = MerlinObservable.from(getApplicationContext())
+        Subscription merlinSubscription = MerlinObservable.from(this)
                 .distinctUntilChanged()
                 .subscribe(new NetworkAction(networkStatusDisplayer, viewToAttachDisplayerTo));
         subscriptions.add(merlinSubscription);

--- a/demo/src/main/java/com/novoda/merlin/demo/presentation/RxJavaDemoActivity.java
+++ b/demo/src/main/java/com/novoda/merlin/demo/presentation/RxJavaDemoActivity.java
@@ -26,7 +26,7 @@ public class RxJavaDemoActivity extends Activity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.main);
         viewToAttachDisplayerTo = findViewById(R.id.displayerAttachableView);
-        networkStatusDisplayer = new NetworkStatusDisplayer(getResources());
+        networkStatusDisplayer = new NetworkStatusDisplayer(getResources(), merlinsBeard);
         merlinsBeard = MerlinsBeard.from(this);
         subscriptions = new CompositeSubscription();
 
@@ -75,7 +75,7 @@ public class RxJavaDemoActivity extends Activity {
 
         @Override
         public void onClick(View view) {
-            networkStatusDisplayer.displayNetworkSubtype(merlinsBeard.getMobileNetworkSubtypeName(), viewToAttachDisplayerTo);
+            networkStatusDisplayer.displayNetworkSubtype(viewToAttachDisplayerTo);
         }
     };
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,28 +1,28 @@
 ext {
     versions = [
-            support   : "25.3.1",
+            support   : '25.3.1',
             androidSdk: [
                     compile   : 25,
                     min       : 14,
-                    buildTools: "25.0.2"
+                    buildTools: '25.0.2'
             ]
     ]
 
     libraries = [
             build: [
-                    androidGradle : "com.android.tools.build:gradle:2.3.1",
-                    bintrayRelease: "com.novoda:bintray-release:0.4.0"
+                    androidGradle : 'com.android.tools.build:gradle:2.3.1',
+                    bintrayRelease: 'com.novoda:bintray-release:0.4.0'
             ],
             app  : [
                     supportAnnotations: "com.android.support:support-annotations:${versions.support}",
                     supportDesign     : "com.android.support:design:${versions.support}",
-                    rxJava            : "io.reactivex:rxjava:1.2.10",
-                    rxJava2           : "io.reactivex.rxjava2:rxjava:2.0.9"
+                    rxJava            : 'io.reactivex:rxjava:1.2.10',
+                    rxJava2           : 'io.reactivex.rxjava2:rxjava:2.0.9'
             ],
             test : [
-                    jUnit  : "junit:junit:4.12",
-                    mockito: "org.mockito:mockito-core:2.7.22",
-                    fest   : "org.easytesting:fest-assert-core:2.0M8"
+                    jUnit  : 'junit:junit:4.12',
+                    mockito: 'org.mockito:mockito-core:2.7.22',
+                    fest   : 'org.easytesting:fest-assert-core:2.0M8'
             ]
     ]
 }


### PR DESCRIPTION
## Problem
As per #127 "Add dispose method" we need to track down memory leaks in the app and patch them. This one started by looking into the `LocalBinder`. 

**Memory Analyzer starting leak:**
![27391161-17cfe3c8-569b-11e7-873a-1e28772042be](https://user-images.githubusercontent.com/3380092/27407614-007d0e2c-56d1-11e7-8900-e05307f6990f.png)

1. `Registerable`s keep a list of callbacks which can be a callback directly to the activity, leaking that activity 😬 

2. We don't actually tell the service to stop when telling it to unbind 🤕  

3. `Binder` keeps a reference to the outer `MerlinService`.

## Solution

1. **Clear** the `Registerable`s when unbinding from an activity.

2. Tell the service to **stop** when we unbind.

3. Remove the reference to the `LocalBinder` when unbinding the `MerlinService`.

**Memory Analyzer allocations after patches:**
![screen shot 2017-06-21 at 22 11 45](https://user-images.githubusercontent.com/3380092/27407620-0a12e1f0-56d1-11e7-91a7-6cca2e6d12e1.png)

### Test(s) added
Yes! Updated necessary tests to verify the additional method calls.

### Screenshots
No UI changes.

### Paired with
Nobody.
