### PR TITLE
NetworkStatusDisplayer crash in demo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 allprojects {
-    version = '1.1.0'
+    version = '1.1.1'
     repositories { mavenCentral() }
 }
 

--- a/demo/src/main/java/com/novoda/merlin/demo/presentation/RxJava2DemoActivity.java
+++ b/demo/src/main/java/com/novoda/merlin/demo/presentation/RxJava2DemoActivity.java
@@ -27,8 +27,8 @@ public class RxJava2DemoActivity extends Activity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.main);
         viewToAttachDisplayerTo = findViewById(R.id.displayerAttachableView);
-        networkStatusDisplayer = new NetworkStatusDisplayer(getResources(), merlinsBeard);
         merlinsBeard = MerlinsBeard.from(this);
+        networkStatusDisplayer = new NetworkStatusDisplayer(getResources(), merlinsBeard);
         disposables = new CompositeDisposable();
 
         findViewById(R.id.current_status).setOnClickListener(networkStatusOnClick);

--- a/demo/src/main/java/com/novoda/merlin/demo/presentation/RxJavaDemoActivity.java
+++ b/demo/src/main/java/com/novoda/merlin/demo/presentation/RxJavaDemoActivity.java
@@ -26,8 +26,8 @@ public class RxJavaDemoActivity extends Activity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.main);
         viewToAttachDisplayerTo = findViewById(R.id.displayerAttachableView);
-        networkStatusDisplayer = new NetworkStatusDisplayer(getResources(), merlinsBeard);
         merlinsBeard = MerlinsBeard.from(this);
+        networkStatusDisplayer = new NetworkStatusDisplayer(getResources(), merlinsBeard);
         subscriptions = new CompositeSubscription();
 
         findViewById(R.id.current_status).setOnClickListener(networkStatusOnClick);


### PR DESCRIPTION
## Problem
Introduced `MerlinsBeard` into the `NetworkStatusDisplayer` and assumed that `Activities` were created in the same way, with `MerlinsBeard` being created in the same place. Don't make assumptions though because now it crashes 😬 

## Solution
Pass `MerlinsBeard` into `NetworkStatusDisplayer`.

### Test(s) added
No tests, but would be good to introduce some to catch stuff like this 😢 

### Screenshots
No UI changes.

### Paired with
Nobody.
