### PR TITLE
Network Status Displayer subtype

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 allprojects {
-    version = '1.1.2'
+    version = '1.1.1'
     repositories { mavenCentral() }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 allprojects {
-    version = '1.1.1'
+    version = '1.1.2'
     repositories { mavenCentral() }
 }
 

--- a/demo/src/main/java/com/novoda/merlin/demo/connectivity/display/NetworkStatusDisplayer.java
+++ b/demo/src/main/java/com/novoda/merlin/demo/connectivity/display/NetworkStatusDisplayer.java
@@ -44,12 +44,11 @@ public class NetworkStatusDisplayer {
 
     }
 
-    @StringRes
-    private int subtypeMessageFrom(String subtype) {
+    private String subtypeMessageFrom(String subtype) {
         if (subtypeAbsent(subtype)) {
-            return R.string.subtype_not_available;
+            return resources.getString(R.string.subtype_not_available);
         } else {
-            return R.string.subtype_value;
+            return resources.getString(R.string.subtype_value, subtype);
         }
     }
 


### PR DESCRIPTION
## Problem
The Subtype information for a mobile network is not properly displayed in the demo application. 
It occurs because we get a given `StringRes` based on whether a `Subtype` is present or not. We don't ever attach the `Subtype` if it is present though, resulting in `Subtype %s` 😱 

## Solution
Get the right resource and attach the `Subtype`.

### Test(s) added
No tests for UI components just yet.

### Screenshots
Updated the Wiki to show the full changes after this PR is merged.
https://github.com/novoda/merlin/wiki/Demo-App-Usecases

### Paired with
Nobody.
