### PR TITLE
MER-139/Null Network info

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 allprojects {
-    version = '1.1.1'
+    version = '1.1.2'
     repositories { mavenCentral() }
 }
 

--- a/core/src/main/java/com/novoda/merlin/MerlinsBeard.java
+++ b/core/src/main/java/com/novoda/merlin/MerlinsBeard.java
@@ -94,7 +94,7 @@ public class MerlinsBeard {
         for (Network network : networks) {
             NetworkInfo networkInfo = connectivityManager.getNetworkInfo(network);
 
-            if (networkInfo.getType() == networkType) {
+            if (networkInfo != null && networkInfo.getType() == networkType) {
                 return networkInfo.isConnected();
             }
 

--- a/core/src/main/java/com/novoda/merlin/MerlinsBeard.java
+++ b/core/src/main/java/com/novoda/merlin/MerlinsBeard.java
@@ -15,6 +15,8 @@ import com.novoda.merlin.service.AndroidVersion;
  */
 public class MerlinsBeard {
 
+    private static final boolean IS_NOT_CONNECTED_TO_NETWORK_TYPE = false;
+
     private final ConnectivityManager connectivityManager;
     private final AndroidVersion androidVersion;
 
@@ -100,7 +102,7 @@ public class MerlinsBeard {
 
         }
 
-        return false;
+        return IS_NOT_CONNECTED_TO_NETWORK_TYPE;
     }
 
     /**

--- a/core/src/test/java/com/novoda/merlin/MerlinsBeardTest.java
+++ b/core/src/test/java/com/novoda/merlin/MerlinsBeardTest.java
@@ -192,12 +192,29 @@ public class MerlinsBeardTest {
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    @Test
+    public void givenNetworkWithoutNetworkInfo_andAndroidVersionIsLollipopOrAbove_whenCheckingIfConnectedToMobile_thenReturnsFalse() {
+        givenNetworkStateWithoutNetworkInfoForLollipopOrAbove();
+
+        boolean connectedToMobileNetwork = merlinsBeard.isConnectedToMobileNetwork();
+
+        assertThat(connectedToMobileNetwork).isFalse();
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     private void givenNetworkStateForLollipopOrAbove(boolean isConnected, int networkType) {
         Network network = Mockito.mock(Network.class);
         NetworkInfo networkInfo = Mockito.mock(NetworkInfo.class);
         given(networkInfo.getType()).willReturn(networkType);
         given(networkInfo.isConnected()).willReturn(isConnected);
         given(connectivityManager.getNetworkInfo(network)).willReturn(networkInfo);
+        given(androidVersion.isLollipopOrHigher()).willReturn(LOLLIPOP_OR_ABOVE);
+        given(connectivityManager.getAllNetworks()).willReturn(new Network[]{network});
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    private void givenNetworkStateWithoutNetworkInfoForLollipopOrAbove() {
+        Network network = Mockito.mock(Network.class);
         given(androidVersion.isLollipopOrHigher()).willReturn(LOLLIPOP_OR_ABOVE);
         given(connectivityManager.getAllNetworks()).willReturn(new Network[]{network});
     }


### PR DESCRIPTION
## Problem
As per, #139, `NetworkInfo`can be `null` at which point we call `getType` will result in a `NullPointException`.

## Solution
Add check for `null` `NetworkInfo`.

### Test(s) added
Yes, added a test to verify the issue and fixed it.

### Screenshots
No UI changes.

### Paired with
Nobody.
