### PR TITLE
Move Logger to logger package

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 allprojects {
-    version = '1.1.2'
+    version = '1.1.3'
     repositories { mavenCentral() }
 }
 

--- a/core/src/main/java/com/novoda/merlin/MerlinBuilder.java
+++ b/core/src/main/java/com/novoda/merlin/MerlinBuilder.java
@@ -12,8 +12,8 @@ import com.novoda.merlin.registerable.disconnection.Disconnectable;
 import com.novoda.merlin.registerable.disconnection.DisconnectCallbackManager;
 import com.novoda.merlin.service.MerlinServiceBinder;
 import com.novoda.merlin.service.ResponseCodeValidator;
-import com.novoda.support.Logger;
-import com.novoda.support.MerlinBackwardsCompatibleLog;
+import com.novoda.merlin.logger.Logger;
+import com.novoda.merlin.logger.MerlinBackwardsCompatibleLog;
 
 import static com.novoda.merlin.service.ResponseCodeValidator.DefaultEndpointResponseCodeValidator;
 

--- a/core/src/main/java/com/novoda/merlin/logger/Logger.java
+++ b/core/src/main/java/com/novoda/merlin/logger/Logger.java
@@ -1,4 +1,4 @@
-package com.novoda.support;
+package com.novoda.merlin.logger;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/core/src/main/java/com/novoda/merlin/logger/MerlinBackwardsCompatibleLog.java
+++ b/core/src/main/java/com/novoda/merlin/logger/MerlinBackwardsCompatibleLog.java
@@ -1,4 +1,4 @@
-package com.novoda.support;
+package com.novoda.merlin.logger;
 
 import android.util.Log;
 

--- a/core/src/main/java/com/novoda/merlin/registerable/bind/BindCallbackManager.java
+++ b/core/src/main/java/com/novoda/merlin/registerable/bind/BindCallbackManager.java
@@ -3,7 +3,7 @@ package com.novoda.merlin.registerable.bind;
 import com.novoda.merlin.NetworkStatus;
 import com.novoda.merlin.registerable.MerlinCallbackManager;
 import com.novoda.merlin.registerable.Register;
-import com.novoda.support.Logger;
+import com.novoda.merlin.logger.Logger;
 
 public class BindCallbackManager extends MerlinCallbackManager<Bindable> {
 

--- a/core/src/main/java/com/novoda/merlin/registerable/connection/ConnectCallbackManager.java
+++ b/core/src/main/java/com/novoda/merlin/registerable/connection/ConnectCallbackManager.java
@@ -2,7 +2,7 @@ package com.novoda.merlin.registerable.connection;
 
 import com.novoda.merlin.registerable.MerlinCallbackManager;
 import com.novoda.merlin.registerable.Register;
-import com.novoda.support.Logger;
+import com.novoda.merlin.logger.Logger;
 
 public class ConnectCallbackManager extends MerlinCallbackManager<Connectable> {
 

--- a/core/src/main/java/com/novoda/merlin/registerable/disconnection/DisconnectCallbackManager.java
+++ b/core/src/main/java/com/novoda/merlin/registerable/disconnection/DisconnectCallbackManager.java
@@ -2,7 +2,7 @@ package com.novoda.merlin.registerable.disconnection;
 
 import com.novoda.merlin.registerable.MerlinCallbackManager;
 import com.novoda.merlin.registerable.Register;
-import com.novoda.support.Logger;
+import com.novoda.merlin.logger.Logger;
 
 public class DisconnectCallbackManager extends MerlinCallbackManager<Disconnectable> implements Disconnectable {
 

--- a/core/src/main/java/com/novoda/merlin/service/MerlinServiceBinder.java
+++ b/core/src/main/java/com/novoda/merlin/service/MerlinServiceBinder.java
@@ -13,7 +13,7 @@ import com.novoda.merlin.receiver.ConnectivityChangesRegister;
 import com.novoda.merlin.registerable.bind.BindCallbackManager;
 import com.novoda.merlin.registerable.connection.ConnectCallbackManager;
 import com.novoda.merlin.registerable.disconnection.DisconnectCallbackManager;
-import com.novoda.support.Logger;
+import com.novoda.merlin.logger.Logger;
 
 public class MerlinServiceBinder {
 

--- a/core/src/main/java/com/novoda/merlin/service/Ping.java
+++ b/core/src/main/java/com/novoda/merlin/service/Ping.java
@@ -2,7 +2,7 @@ package com.novoda.merlin.service;
 
 import com.novoda.merlin.Endpoint;
 import com.novoda.merlin.service.request.RequestException;
-import com.novoda.support.Logger;
+import com.novoda.merlin.logger.Logger;
 
 class Ping {
 

--- a/demo/src/main/java/com/novoda/merlin/demo/presentation/base/MerlinActivity.java
+++ b/demo/src/main/java/com/novoda/merlin/demo/presentation/base/MerlinActivity.java
@@ -8,7 +8,7 @@ import com.novoda.merlin.Merlin;
 import com.novoda.merlin.registerable.bind.Bindable;
 import com.novoda.merlin.registerable.connection.Connectable;
 import com.novoda.merlin.registerable.disconnection.Disconnectable;
-import com.novoda.support.Logger;
+import com.novoda.merlin.logger.Logger;
 
 public abstract class MerlinActivity extends AppCompatActivity {
 


### PR DESCRIPTION
## Problem
When building some client projects we receive `java.util.zip.ZipException: duplicate entry: com/novoda/support/Logger` error. This occurs because of prolific use of the `com.novoda.support` package in our apps and libraries, combined with common naming conventions.

## Solution
Move the `Logger` code to the `com.novoda.merlin.logger` package. It is used by `Merlin`, should it be used anyone else for anything else other than `Merlin`? No, not really. If it is to be used for anything else it should be moved to another repository.

Ideally, in the future, I would like to collapse the package structure of `Merlin`. Collapsing the package structure would expose only those classes that we expect clients to use and hide the internals of `Merlin`. https://github.com/novoda/merlin/issues/142

### Test(s) added
No, just moving packages.

### Screenshots
No UI changes.

### Paired with
Nobody.
