### PR TITLE
MER-146/Bind callback crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 allprojects {
-    version = '1.1.3'
+    version = '1.1.4'
     repositories { mavenCentral() }
 }
 

--- a/core/src/main/java/com/novoda/merlin/service/ConnectivityChangesForwarder.java
+++ b/core/src/main/java/com/novoda/merlin/service/ConnectivityChangesForwarder.java
@@ -29,6 +29,10 @@ class ConnectivityChangesForwarder {
     }
 
     void forwardInitialNetworkStatus() {
+        if (bindCallbackManager == null) {
+            return;
+        }
+
         if (hasPerformedEndpointPing()) {
             bindCallbackManager.onMerlinBind(lastEndpointPingNetworkStatus);
             return;

--- a/core/src/test/java/com/novoda/merlin/service/ConnectivityChangesForwarderTest.java
+++ b/core/src/test/java/com/novoda/merlin/service/ConnectivityChangesForwarderTest.java
@@ -74,7 +74,7 @@ public class ConnectivityChangesForwarderTest {
     }
 
     @Test
-    public void givenEndpointIsUnavailable_whenNotifyingOfInitialState_thenForwardsNetworkAvailableToListener() {
+    public void givenEndpointPingHasNotOccurred_whenNotifyingOfInitialState_thenForwardsNetworkAvailableToListener() {
         given(networkStatusRetriever.retrieveNetworkStatus()).willReturn(AVAILABLE_NETWORK);
 
         connectivityChangesForwarder.forwardInitialNetworkStatus();
@@ -122,7 +122,7 @@ public class ConnectivityChangesForwarderTest {
     }
 
     @Test
-    public void givenEndpointIsUnavailable_andNullBindListener_whenNotifyingOfInitialState_thenForwardsNetworkAvailableToListener() {
+    public void givenEndpointPingHasNotOccurred_andNullBindListener_whenNotifyingOfInitialState_thenForwardsNetworkAvailableToListener() {
         connectivityChangesForwarder = new ConnectivityChangesForwarder(
                 networkStatusRetriever, disconnectCallbackManager, connectCallbackManager, null, endpointPinger
         );

--- a/core/src/test/java/com/novoda/merlin/service/ConnectivityChangesForwarderTest.java
+++ b/core/src/test/java/com/novoda/merlin/service/ConnectivityChangesForwarderTest.java
@@ -110,7 +110,7 @@ public class ConnectivityChangesForwarderTest {
     }
 
     @Test
-    public void givenNetworkWasConnected_butNullBindListener_whenNotifyingOfInitialState_thenForwardsNetworkAvailableToListener() {
+    public void givenNetworkWasConnected_andNullBindListener_whenNotifyingOfInitialState_thenForwardsNetworkAvailableToListener() {
         connectivityChangesForwarder = new ConnectivityChangesForwarder(
                 networkStatusRetriever, disconnectCallbackManager, connectCallbackManager, null, endpointPinger
         );
@@ -134,7 +134,7 @@ public class ConnectivityChangesForwarderTest {
     }
 
     @Test
-    public void givenFetchingWithPing_butNullConnectListener_whenSuccessful_thenNeverCallsOnConnect() {
+    public void givenFetchingWithPing_andNullConnectListener_whenSuccessful_thenNeverCallsOnConnect() {
         connectivityChangesForwarder = new ConnectivityChangesForwarder(
                 networkStatusRetriever, disconnectCallbackManager, null, bindCallbackManager, endpointPinger
         );
@@ -146,7 +146,7 @@ public class ConnectivityChangesForwarderTest {
     }
 
     @Test
-    public void givenFetchingWithPing_butNullDisconnectListener_whenUnsuccessful_thenNeverCallsOnDisconnect() {
+    public void givenFetchingWithPing_andNullDisconnectListener_whenUnsuccessful_thenNeverCallsOnDisconnect() {
         connectivityChangesForwarder = new ConnectivityChangesForwarder(
                 networkStatusRetriever, null, connectCallbackManager, bindCallbackManager, endpointPinger
         );

--- a/core/src/test/java/com/novoda/merlin/service/ConnectivityChangesForwarderTest.java
+++ b/core/src/test/java/com/novoda/merlin/service/ConnectivityChangesForwarderTest.java
@@ -56,6 +56,15 @@ public class ConnectivityChangesForwarderTest {
     }
 
     @Test
+    public void givenNetworkWasConnected_whenNotifyingOfInitialState_thenForwardsNetworkAvailableToListener() {
+        givenNetworkWas(CONNECTED);
+
+        connectivityChangesForwarder.forwardInitialNetworkStatus();
+
+        verify(bindCallbackManager).onMerlinBind(AVAILABLE_NETWORK);
+    }
+
+    @Test
     public void givenNetworkWasDisconnected_whenNotifyingOfInitialState_thenForwardsNetworkUnavailableToListener() {
         givenNetworkWas(DISCONNECTED);
 

--- a/core/src/test/java/com/novoda/merlin/service/ConnectivityChangesForwarderTest.java
+++ b/core/src/test/java/com/novoda/merlin/service/ConnectivityChangesForwarderTest.java
@@ -56,15 +56,6 @@ public class ConnectivityChangesForwarderTest {
     }
 
     @Test
-    public void givenNetworkWasConnected_whenNotifyingOfInitialState_thenForwardsNetworkAvailableToListener() {
-        givenNetworkWas(CONNECTED);
-
-        connectivityChangesForwarder.forwardInitialNetworkStatus();
-
-        verify(bindCallbackManager).onMerlinBind(AVAILABLE_NETWORK);
-    }
-
-    @Test
     public void givenNetworkWasDisconnected_whenNotifyingOfInitialState_thenForwardsNetworkUnavailableToListener() {
         givenNetworkWas(DISCONNECTED);
 
@@ -107,6 +98,30 @@ public class ConnectivityChangesForwarderTest {
         pingerCallback.onFailure();
 
         verify(disconnectCallbackManager).onDisconnect();
+    }
+
+    @Test
+    public void givenNetworkWasConnected_butNullBindListener_whenNotifyingOfInitialState_thenForwardsNetworkAvailableToListener() {
+        connectivityChangesForwarder = new ConnectivityChangesForwarder(
+                networkStatusRetriever, disconnectCallbackManager, connectCallbackManager, null, endpointPinger
+        );
+        givenNetworkWas(CONNECTED);
+
+        connectivityChangesForwarder.forwardInitialNetworkStatus();
+
+        verify(bindCallbackManager, never()).onMerlinBind(any(NetworkStatus.class));
+    }
+
+    @Test
+    public void givenEndpointIsUnavailable_andNullBindListener_whenNotifyingOfInitialState_thenForwardsNetworkAvailableToListener() {
+        connectivityChangesForwarder = new ConnectivityChangesForwarder(
+                networkStatusRetriever, disconnectCallbackManager, connectCallbackManager, null, endpointPinger
+        );
+        given(networkStatusRetriever.retrieveNetworkStatus()).willReturn(AVAILABLE_NETWORK);
+
+        connectivityChangesForwarder.forwardInitialNetworkStatus();
+
+        verify(bindCallbackManager, never()).onMerlinBind(any(NetworkStatus.class));
     }
 
     @Test


### PR DESCRIPTION
## Problem
As per issue #146, calling `Merlin.bind` crashes when the `withBindableCallbacks` has not been specified when using `MerlinBuilder` to build an instance of `Merlin`. The `onBind` callback is an event that a client **can** register for, it is not compulsory, and hence, the `bindCallbackManager` can be null.

## Solution
Add a null check to the `ConnectivityChangesForwarder` and only forward `onBind` events when the `bindCallbackManager` is not null.

### Test(s) added
Yes, two tests were added to show the crash and then the `ConnectivityChangesForwarder` patched.

### Screenshots
No UI changes.

### Paired with
Nobody.
