### PR TITLE
MER-149/Forwarder null pointer

### DIFF
--- a/core/src/main/java/com/novoda/merlin/MerlinBuilder.java
+++ b/core/src/main/java/com/novoda/merlin/MerlinBuilder.java
@@ -2,18 +2,18 @@ package com.novoda.merlin;
 
 import android.content.Context;
 
-import com.novoda.merlin.registerable.Register;
-import com.novoda.merlin.registerable.Registrar;
-import com.novoda.merlin.registerable.bind.Bindable;
-import com.novoda.merlin.registerable.bind.BindCallbackManager;
-import com.novoda.merlin.registerable.connection.Connectable;
-import com.novoda.merlin.registerable.connection.ConnectCallbackManager;
-import com.novoda.merlin.registerable.disconnection.Disconnectable;
-import com.novoda.merlin.registerable.disconnection.DisconnectCallbackManager;
-import com.novoda.merlin.service.MerlinServiceBinder;
-import com.novoda.merlin.service.ResponseCodeValidator;
 import com.novoda.merlin.logger.Logger;
 import com.novoda.merlin.logger.MerlinBackwardsCompatibleLog;
+import com.novoda.merlin.registerable.Register;
+import com.novoda.merlin.registerable.Registrar;
+import com.novoda.merlin.registerable.bind.BindCallbackManager;
+import com.novoda.merlin.registerable.bind.Bindable;
+import com.novoda.merlin.registerable.connection.ConnectCallbackManager;
+import com.novoda.merlin.registerable.connection.Connectable;
+import com.novoda.merlin.registerable.disconnection.DisconnectCallbackManager;
+import com.novoda.merlin.registerable.disconnection.Disconnectable;
+import com.novoda.merlin.service.MerlinServiceBinder;
+import com.novoda.merlin.service.ResponseCodeValidator;
 
 import static com.novoda.merlin.service.ResponseCodeValidator.DefaultEndpointResponseCodeValidator;
 

--- a/core/src/main/java/com/novoda/merlin/receiver/ConnectivityCallbacks.java
+++ b/core/src/main/java/com/novoda/merlin/receiver/ConnectivityCallbacks.java
@@ -5,6 +5,7 @@ import android.net.ConnectivityManager;
 import android.net.Network;
 import android.os.Build;
 
+import com.novoda.merlin.logger.Logger;
 import com.novoda.merlin.service.ConnectivityChangeEventExtractor;
 import com.novoda.merlin.service.MerlinService;
 
@@ -36,10 +37,12 @@ class ConnectivityCallbacks extends ConnectivityManager.NetworkCallback {
     }
 
     private void notifyMerlinService(Network network) {
-        if (connectivityChangesNotifier.canNotify()) {
-            ConnectivityChangeEvent connectivityChangeEvent = connectivityChangeEventExtractor.extractFrom(network);
-            connectivityChangesNotifier.notify(connectivityChangeEvent);
+        if (!connectivityChangesNotifier.canNotify()) {
+            Logger.d("Cannot notify " + MerlinService.ConnectivityChangesNotifier.class.getSimpleName());
+            return;
         }
+        ConnectivityChangeEvent connectivityChangeEvent = connectivityChangeEventExtractor.extractFrom(network);
+        connectivityChangesNotifier.notify(connectivityChangeEvent);
     }
 
 }

--- a/core/src/main/java/com/novoda/merlin/receiver/ConnectivityCallbacks.java
+++ b/core/src/main/java/com/novoda/merlin/receiver/ConnectivityCallbacks.java
@@ -3,20 +3,21 @@ package com.novoda.merlin.receiver;
 import android.annotation.TargetApi;
 import android.net.ConnectivityManager;
 import android.net.Network;
-import android.net.NetworkInfo;
 import android.os.Build;
 
+import com.novoda.merlin.service.ConnectivityChangeEventExtractor;
 import com.novoda.merlin.service.MerlinService;
 
 @TargetApi(Build.VERSION_CODES.LOLLIPOP)
 class ConnectivityCallbacks extends ConnectivityManager.NetworkCallback {
 
-    private final ConnectivityManager connectivityManager;
     private final MerlinService.ConnectivityChangesNotifier connectivityChangesNotifier;
+    private final ConnectivityChangeEventExtractor connectivityChangeEventExtractor;
 
-    ConnectivityCallbacks(ConnectivityManager connectivityManager, MerlinService.ConnectivityChangesNotifier connectivityChangesNotifier) {
-        this.connectivityManager = connectivityManager;
+    ConnectivityCallbacks(MerlinService.ConnectivityChangesNotifier connectivityChangesNotifier,
+                          ConnectivityChangeEventExtractor connectivityChangeEventExtractor) {
         this.connectivityChangesNotifier = connectivityChangesNotifier;
+        this.connectivityChangeEventExtractor = connectivityChangeEventExtractor;
     }
 
     @Override
@@ -36,22 +37,8 @@ class ConnectivityCallbacks extends ConnectivityManager.NetworkCallback {
 
     private void notifyMerlinService(Network network) {
         if (connectivityChangesNotifier.canNotify()) {
-            ConnectivityChangeEvent connectivityChangeEvent = extractConnectivityChangeEventFrom(network);
+            ConnectivityChangeEvent connectivityChangeEvent = connectivityChangeEventExtractor.extractFrom(network);
             connectivityChangesNotifier.notify(connectivityChangeEvent);
-        }
-    }
-
-    private ConnectivityChangeEvent extractConnectivityChangeEventFrom(Network network) {
-        NetworkInfo networkInfo = connectivityManager.getNetworkInfo(network);
-
-        if (null != networkInfo) {
-            boolean connected = networkInfo.isConnected();
-            String reason = networkInfo.getReason();
-            String extraInfo = networkInfo.getExtraInfo();
-
-            return ConnectivityChangeEvent.createWithNetworkInfoChangeEvent(connected, extraInfo, reason);
-        } else {
-            return ConnectivityChangeEvent.createWithoutConnection();
         }
     }
 

--- a/core/src/main/java/com/novoda/merlin/receiver/ConnectivityCallbacks.java
+++ b/core/src/main/java/com/novoda/merlin/receiver/ConnectivityCallbacks.java
@@ -35,12 +35,10 @@ class ConnectivityCallbacks extends ConnectivityManager.NetworkCallback {
     }
 
     private void notifyMerlinService(Network network) {
-        ConnectivityChangeEvent connectivityChangeEvent = extractConnectivityChangeEventFrom(network);
-
         if (connectivityChangesNotifier.canNotify()) {
+            ConnectivityChangeEvent connectivityChangeEvent = extractConnectivityChangeEventFrom(network);
             connectivityChangesNotifier.notify(connectivityChangeEvent);
         }
-
     }
 
     private ConnectivityChangeEvent extractConnectivityChangeEventFrom(Network network) {

--- a/core/src/main/java/com/novoda/merlin/receiver/ConnectivityChangeEvent.java
+++ b/core/src/main/java/com/novoda/merlin/receiver/ConnectivityChangeEvent.java
@@ -12,7 +12,7 @@ public class ConnectivityChangeEvent {
     private final String info;
     private final String reason;
 
-    static ConnectivityChangeEvent createWithoutConnection() {
+    public static ConnectivityChangeEvent createWithoutConnection() {
         return new ConnectivityChangeEvent(WITHOUT_CONNECTION, WITHOUT_INFO, WITHOUT_REASON);
     }
 

--- a/core/src/main/java/com/novoda/merlin/receiver/ConnectivityChangesRegister.java
+++ b/core/src/main/java/com/novoda/merlin/receiver/ConnectivityChangesRegister.java
@@ -8,6 +8,7 @@ import android.net.NetworkRequest;
 import android.os.Build;
 
 import com.novoda.merlin.service.AndroidVersion;
+import com.novoda.merlin.service.ConnectivityChangeEventExtractor;
 import com.novoda.merlin.service.MerlinService;
 
 public class ConnectivityChangesRegister {
@@ -15,16 +16,19 @@ public class ConnectivityChangesRegister {
     private final Context context;
     private final ConnectivityManager connectivityManager;
     private final AndroidVersion androidVersion;
+    private final ConnectivityChangeEventExtractor connectivityChangeEventExtractor;
 
     private ConnectivityReceiver connectivityReceiver;
     private ConnectivityCallbacks connectivityCallbacks;
 
     public ConnectivityChangesRegister(Context context,
                                        ConnectivityManager connectivityManager,
-                                       AndroidVersion androidVersion) {
+                                       AndroidVersion androidVersion,
+                                       ConnectivityChangeEventExtractor connectivityChangeEventExtractor) {
         this.context = context;
         this.connectivityManager = connectivityManager;
         this.androidVersion = androidVersion;
+        this.connectivityChangeEventExtractor = connectivityChangeEventExtractor;
     }
 
     public void register(MerlinService.ConnectivityChangesNotifier connectivityChangesNotifier) {
@@ -43,7 +47,7 @@ public class ConnectivityChangesRegister {
 
     private ConnectivityCallbacks connectivityCallbacks(MerlinService.ConnectivityChangesNotifier connectivityChangesNotifier) {
         if (connectivityCallbacks == null) {
-            connectivityCallbacks = new ConnectivityCallbacks(connectivityManager, connectivityChangesNotifier);
+            connectivityCallbacks = new ConnectivityCallbacks(connectivityChangesNotifier, connectivityChangeEventExtractor);
         }
         return connectivityCallbacks;
     }

--- a/core/src/main/java/com/novoda/merlin/receiver/ConnectivityChangesRegister.java
+++ b/core/src/main/java/com/novoda/merlin/receiver/ConnectivityChangesRegister.java
@@ -27,23 +27,23 @@ public class ConnectivityChangesRegister {
         this.androidVersion = androidVersion;
     }
 
-    public void register(MerlinService.ConnectivityChangesListener connectivityChangesListener) {
+    public void register(MerlinService.ConnectivityChangesNotifier connectivityChangesNotifier) {
         if (androidVersion.isLollipopOrHigher()) {
-            registerNetworkCallbacks(connectivityChangesListener);
+            registerNetworkCallbacks(connectivityChangesNotifier);
         } else {
             registerBroadcastReceiver();
         }
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    private void registerNetworkCallbacks(MerlinService.ConnectivityChangesListener connectivityChangesListener) {
+    private void registerNetworkCallbacks(MerlinService.ConnectivityChangesNotifier connectivityChangesNotifier) {
         NetworkRequest.Builder builder = new NetworkRequest.Builder();
-        connectivityManager.registerNetworkCallback(builder.build(), connectivityCallbacks(connectivityChangesListener));
+        connectivityManager.registerNetworkCallback(builder.build(), connectivityCallbacks(connectivityChangesNotifier));
     }
 
-    private ConnectivityCallbacks connectivityCallbacks(MerlinService.ConnectivityChangesListener connectivityChangesListener) {
+    private ConnectivityCallbacks connectivityCallbacks(MerlinService.ConnectivityChangesNotifier connectivityChangesNotifier) {
         if (connectivityCallbacks == null) {
-            connectivityCallbacks = new ConnectivityCallbacks(connectivityManager, connectivityChangesListener);
+            connectivityCallbacks = new ConnectivityCallbacks(connectivityManager, connectivityChangesNotifier);
         }
         return connectivityCallbacks;
     }

--- a/core/src/main/java/com/novoda/merlin/receiver/ConnectivityReceiver.java
+++ b/core/src/main/java/com/novoda/merlin/receiver/ConnectivityReceiver.java
@@ -23,10 +23,9 @@ public class ConnectivityReceiver extends BroadcastReceiver {
 
         MerlinBinderRetriever merlinBinderRetriever = new MerlinBinderRetriever() {
             @Override
-            public MerlinService.ConnectivityChangesNotifier retrieveConnectivityChangesNotifierIfAvailable(Context context) {
+            public MerlinService.ConnectivityChangesNotifier retrieveConnectivityChangesNotifier(Context context) {
                 IBinder iBinder = peekService(context, new Intent(context, MerlinService.class));
-                if (iBinder != null
-                        && iBinder instanceof MerlinService.ConnectivityChangesNotifier) {
+                if (iBinder instanceof MerlinService.ConnectivityChangesNotifier) {
                     return (MerlinService.ConnectivityChangesNotifier) iBinder;
                 }
                 return null;
@@ -49,7 +48,7 @@ public class ConnectivityReceiver extends BroadcastReceiver {
     interface MerlinBinderRetriever {
 
         @Nullable
-        MerlinService.ConnectivityChangesNotifier retrieveConnectivityChangesNotifierIfAvailable(Context context);
+        MerlinService.ConnectivityChangesNotifier retrieveConnectivityChangesNotifier(Context context);
     }
 
     interface MerlinsBeardCreator {

--- a/core/src/main/java/com/novoda/merlin/receiver/ConnectivityReceiver.java
+++ b/core/src/main/java/com/novoda/merlin/receiver/ConnectivityReceiver.java
@@ -11,7 +11,7 @@ import com.novoda.merlin.service.MerlinService;
 
 public class ConnectivityReceiver extends BroadcastReceiver {
 
-    private final ConnectivityChangeNotifier connectivityChangeNotifier;
+    private final ConnectivityReceiverConnectivityChangeNotifier connectivityReceiverConnectivityChangeNotifier;
 
     public ConnectivityReceiver() {
         MerlinsBeardCreator merlinsBeardCreator = new MerlinsBeardCreator() {
@@ -23,28 +23,33 @@ public class ConnectivityReceiver extends BroadcastReceiver {
 
         MerlinBinderRetriever merlinBinderRetriever = new MerlinBinderRetriever() {
             @Override
-            public IBinder retrieveMerlinLocalServiceBinderIfAvailable(Context context) {
-                return peekService(context, new Intent(context, MerlinService.class));
+            public MerlinService.ConnectivityChangesNotifier retrieveConnectivityChangesNotifierIfAvailable(Context context) {
+                IBinder iBinder = peekService(context, new Intent(context, MerlinService.class));
+                if (iBinder != null
+                        && iBinder instanceof MerlinService.ConnectivityChangesNotifier) {
+                    return (MerlinService.ConnectivityChangesNotifier) iBinder;
+                }
+                return null;
             }
         };
 
         ConnectivityChangeEventCreator creator = new ConnectivityChangeEventCreator();
-        connectivityChangeNotifier = new ConnectivityChangeNotifier(merlinsBeardCreator, merlinBinderRetriever, creator);
+        connectivityReceiverConnectivityChangeNotifier = new ConnectivityReceiverConnectivityChangeNotifier(merlinsBeardCreator, merlinBinderRetriever, creator);
     }
 
-    ConnectivityReceiver(ConnectivityChangeNotifier connectivityChangeNotifier) {
-        this.connectivityChangeNotifier = connectivityChangeNotifier;
+    ConnectivityReceiver(ConnectivityReceiverConnectivityChangeNotifier connectivityReceiverConnectivityChangeNotifier) {
+        this.connectivityReceiverConnectivityChangeNotifier = connectivityReceiverConnectivityChangeNotifier;
     }
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        connectivityChangeNotifier.notify(context, intent);
+        connectivityReceiverConnectivityChangeNotifier.notify(context, intent);
     }
 
     interface MerlinBinderRetriever {
 
         @Nullable
-        IBinder retrieveMerlinLocalServiceBinderIfAvailable(Context context);
+        MerlinService.ConnectivityChangesNotifier retrieveConnectivityChangesNotifierIfAvailable(Context context);
     }
 
     interface MerlinsBeardCreator {

--- a/core/src/main/java/com/novoda/merlin/receiver/ConnectivityReceiverConnectivityChangeNotifier.java
+++ b/core/src/main/java/com/novoda/merlin/receiver/ConnectivityReceiverConnectivityChangeNotifier.java
@@ -32,7 +32,7 @@ class ConnectivityReceiverConnectivityChangeNotifier {
     }
 
     private void notifyMerlinService(Context context, ConnectivityChangeEvent connectivityChangeEvent) {
-        MerlinService.ConnectivityChangesNotifier notifier = merlinBinderRetriever.retrieveConnectivityChangesNotifierIfAvailable(context);
+        MerlinService.ConnectivityChangesNotifier notifier = merlinBinderRetriever.retrieveConnectivityChangesNotifier(context);
 
         if (cannotNotify(notifier)) {
             Logger.d("Cannot notify " + MerlinService.ConnectivityChangesNotifier.class.getSimpleName());

--- a/core/src/main/java/com/novoda/merlin/receiver/ConnectivityReceiverConnectivityChangeNotifier.java
+++ b/core/src/main/java/com/novoda/merlin/receiver/ConnectivityReceiverConnectivityChangeNotifier.java
@@ -35,7 +35,7 @@ class ConnectivityReceiverConnectivityChangeNotifier {
         MerlinService.ConnectivityChangesNotifier notifier = merlinBinderRetriever.retrieveConnectivityChangesNotifierIfAvailable(context);
 
         if (cannotNotify(notifier)) {
-            Logger.d(MerlinService.ConnectivityChangesNotifier.class.getSimpleName() + " is null");
+            Logger.d("Cannot notify " + MerlinService.ConnectivityChangesNotifier.class.getSimpleName());
             return;
         }
         notifier.notify(connectivityChangeEvent);

--- a/core/src/main/java/com/novoda/merlin/service/ConnectivityChangeEventExtractor.java
+++ b/core/src/main/java/com/novoda/merlin/service/ConnectivityChangeEventExtractor.java
@@ -1,0 +1,34 @@
+package com.novoda.merlin.service;
+
+import android.annotation.TargetApi;
+import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkInfo;
+import android.os.Build;
+
+import com.novoda.merlin.receiver.ConnectivityChangeEvent;
+
+@TargetApi(Build.VERSION_CODES.LOLLIPOP)
+public class ConnectivityChangeEventExtractor {
+
+    private final ConnectivityManager connectivityManager;
+
+    public ConnectivityChangeEventExtractor(ConnectivityManager connectivityManager) {
+        this.connectivityManager = connectivityManager;
+    }
+
+    public ConnectivityChangeEvent extractFrom(Network network) {
+        NetworkInfo networkInfo = connectivityManager.getNetworkInfo(network);
+
+        if (null != networkInfo) {
+            boolean connected = networkInfo.isConnected();
+            String reason = networkInfo.getReason();
+            String extraInfo = networkInfo.getExtraInfo();
+
+            return ConnectivityChangeEvent.createWithNetworkInfoChangeEvent(connected, extraInfo, reason);
+        } else {
+            return ConnectivityChangeEvent.createWithoutConnection();
+        }
+    }
+
+}

--- a/core/src/main/java/com/novoda/merlin/service/ConnectivityChangeEventExtractor.java
+++ b/core/src/main/java/com/novoda/merlin/service/ConnectivityChangeEventExtractor.java
@@ -13,7 +13,7 @@ public class ConnectivityChangeEventExtractor {
 
     private final ConnectivityManager connectivityManager;
 
-    public ConnectivityChangeEventExtractor(ConnectivityManager connectivityManager) {
+    ConnectivityChangeEventExtractor(ConnectivityManager connectivityManager) {
         this.connectivityManager = connectivityManager;
     }
 

--- a/core/src/main/java/com/novoda/merlin/service/MerlinService.java
+++ b/core/src/main/java/com/novoda/merlin/service/MerlinService.java
@@ -67,14 +67,34 @@ public class MerlinService extends Service {
         }
     };
 
+    private void notify(ConnectivityChangeEvent connectivityChangeEvent) {
+        assertDependenciesBound();
+
+        connectivityChangesForwarder.forward(connectivityChangeEvent);
+    }
+
     public interface ConnectivityChangesListener {
         void onConnectivityChanged(ConnectivityChangeEvent connectivityChangeEvent);
     }
 
-    public class LocalBinder extends Binder {
+    public interface ConnectivityChangesNotifier {
 
-        public ConnectivityChangesListener connectivityChangesListener() {
-            return MerlinService.this.connectivityChangesListener;
+        boolean canNotify();
+
+        void notify(ConnectivityChangeEvent connectivityChangeEvent);
+
+    }
+
+    class LocalBinder extends Binder implements ConnectivityChangesNotifier {
+
+        @Override
+        public boolean canNotify() {
+            return MerlinService.isBound();
+        }
+
+        @Override
+        public void notify(ConnectivityChangeEvent connectivityChangeEvent) {
+            MerlinService.this.notify(connectivityChangeEvent);
         }
 
         void setConnectivityChangesRegister(ConnectivityChangesRegister connectivityChangesRegister) {

--- a/core/src/main/java/com/novoda/merlin/service/MerlinServiceBinder.java
+++ b/core/src/main/java/com/novoda/merlin/service/MerlinServiceBinder.java
@@ -72,10 +72,12 @@ public class MerlinServiceBinder {
             Logger.d("onServiceConnected");
             MerlinService.LocalBinder merlinServiceBinder = ((MerlinService.LocalBinder) binder);
             ConnectivityManager connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+            ConnectivityChangeEventExtractor connectivityChangeEventExtractor = new ConnectivityChangeEventExtractor(connectivityManager);
             ConnectivityChangesRegister connectivityChangesRegister = new ConnectivityChangesRegister(
                     context,
                     connectivityManager,
-                    new AndroidVersion()
+                    new AndroidVersion(),
+                    connectivityChangeEventExtractor
             );
             NetworkStatusRetriever networkStatusRetriever = new NetworkStatusRetriever(MerlinsBeard.from(context));
             EndpointPinger endpointPinger = EndpointPinger.withCustomEndpointAndValidation(endpoint, validator);

--- a/core/src/main/java/com/novoda/merlin/service/MerlinServiceBinder.java
+++ b/core/src/main/java/com/novoda/merlin/service/MerlinServiceBinder.java
@@ -9,11 +9,11 @@ import android.os.IBinder;
 
 import com.novoda.merlin.Endpoint;
 import com.novoda.merlin.MerlinsBeard;
+import com.novoda.merlin.logger.Logger;
 import com.novoda.merlin.receiver.ConnectivityChangesRegister;
 import com.novoda.merlin.registerable.bind.BindCallbackManager;
 import com.novoda.merlin.registerable.connection.ConnectCallbackManager;
 import com.novoda.merlin.registerable.disconnection.DisconnectCallbackManager;
-import com.novoda.merlin.logger.Logger;
 
 public class MerlinServiceBinder {
 

--- a/core/src/test/java/com/novoda/merlin/receiver/ConnectivityCallbacksTest.java
+++ b/core/src/test/java/com/novoda/merlin/receiver/ConnectivityCallbacksTest.java
@@ -63,30 +63,30 @@ public class ConnectivityCallbacksTest {
     }
 
     @Test
-    public void givenConnectedNetworkInfo_whenNetworkIsAvailable_thenNotifiesMerlinServiceOfConnectedNetwork() {
+    public void givenConnectedNetworkInfo_whenNetworkIsAvailable_thenNotifiesOfConnectedNetwork() {
         NetworkInfo connectedNetworkInfo = givenNetworkInfoWith(CONNECTED, ANY_REASON, ANY_EXTRA_INFO);
 
         networkCallbacks.onAvailable(network);
 
-        thenNotifiesMerlinServiceOf(connectedNetworkInfo);
+        thenNotifies();
     }
 
     @Test
-    public void givenDisconnectedNetworkInfo_whenLosingNetwork_thenNotifiesMerlinServiceOfDisconnectedNetwork() {
+    public void givenDisconnectedNetworkInfo_whenLosingNetwork_thenNotifiesOfDisconnectedNetwork() {
         NetworkInfo disconnectedNetworkInfo = givenNetworkInfoWith(DISCONNECTED, ANY_REASON, ANY_EXTRA_INFO);
 
         networkCallbacks.onLosing(network, MAX_MS_TO_LIVE);
 
-        thenNotifiesMerlinServiceOf(disconnectedNetworkInfo);
+        thenNotifies();
     }
 
     @Test
-    public void givenDisconnectedNetworkInfo_whenNetworkIsLost_thenNotifiesMerlinServiceOfLostNetwork() {
+    public void givenDisconnectedNetworkInfo_whenNetworkIsLost_thenNotifiesOfLostNetwork() {
         NetworkInfo disconnectedNetworkInfo = givenNetworkInfoWith(DISCONNECTED, ANY_REASON, ANY_EXTRA_INFO);
 
         networkCallbacks.onLost(network);
 
-        thenNotifiesMerlinServiceOf(disconnectedNetworkInfo);
+        thenNotifies();
     }
 
     @Test
@@ -134,7 +134,7 @@ public class ConnectivityCallbacksTest {
         return networkInfo;
     }
 
-    private void thenNotifiesMerlinServiceOf(NetworkInfo networkInfo) {
+    private void thenNotifies() {
         ArgumentCaptor<ConnectivityChangeEvent> argumentCaptor = ArgumentCaptor.forClass(ConnectivityChangeEvent.class);
         verify(connectivityChangesNotifier).notify(argumentCaptor.capture());
         assertThat(argumentCaptor.getValue()).isEqualTo(ANY_CONNECTIVITY_CHANGE_EVENT);

--- a/core/src/test/java/com/novoda/merlin/receiver/ConnectivityCallbacksTest.java
+++ b/core/src/test/java/com/novoda/merlin/receiver/ConnectivityCallbacksTest.java
@@ -39,7 +39,7 @@ public class ConnectivityCallbacksTest {
     @Mock
     private ConnectivityManager connectivityManager;
     @Mock
-    private MerlinService.ConnectivityChangesListener connectivityChangesListener;
+    private MerlinService.ConnectivityChangesNotifier connectivityChangesNotifier;
     @Mock
     private Network network;
 
@@ -47,7 +47,7 @@ public class ConnectivityCallbacksTest {
 
     @Before
     public void setUp() {
-        networkCallbacks = new ConnectivityCallbacks(connectivityManager, connectivityChangesListener);
+        networkCallbacks = new ConnectivityCallbacks(connectivityManager, connectivityChangesNotifier);
     }
 
     @Test
@@ -112,7 +112,7 @@ public class ConnectivityCallbacksTest {
 
     private void thenNotifiesMerlinServiceOf(NetworkInfo networkInfo) {
         ArgumentCaptor<ConnectivityChangeEvent> argumentCaptor = ArgumentCaptor.forClass(ConnectivityChangeEvent.class);
-        verify(connectivityChangesListener).onConnectivityChanged(argumentCaptor.capture());
+        verify(connectivityChangesNotifier).notify(argumentCaptor.capture());
         assertThat(argumentCaptor.getValue()).isEqualTo(ConnectivityChangeEvent.createWithNetworkInfoChangeEvent(
                 networkInfo.isConnected(),
                 networkInfo.getExtraInfo(),
@@ -122,7 +122,7 @@ public class ConnectivityCallbacksTest {
 
     private void thenNotifiesMerlinServiceOfMissingNetwork() {
         ArgumentCaptor<ConnectivityChangeEvent> argumentCaptor = ArgumentCaptor.forClass(ConnectivityChangeEvent.class);
-        verify(connectivityChangesListener).onConnectivityChanged(argumentCaptor.capture());
+        verify(connectivityChangesNotifier).notify(argumentCaptor.capture());
         assertThat(argumentCaptor.getValue()).isEqualTo(ConnectivityChangeEvent.createWithoutConnection());
     }
 

--- a/core/src/test/java/com/novoda/merlin/receiver/ConnectivityCallbacksTest.java
+++ b/core/src/test/java/com/novoda/merlin/receiver/ConnectivityCallbacksTest.java
@@ -12,14 +12,14 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 public class ConnectivityCallbacksTest {
 
@@ -32,6 +32,8 @@ public class ConnectivityCallbacksTest {
     private static final int MAX_MS_TO_LIVE = 0;
 
     private static final Network MISSING_NETWORK = null;
+    private static final boolean CAN_NOTIFY = true;
+    private static final boolean CANNOT_NOTIFY = false;
 
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
@@ -47,6 +49,8 @@ public class ConnectivityCallbacksTest {
 
     @Before
     public void setUp() {
+        given(connectivityChangesNotifier.canNotify()).willReturn(CAN_NOTIFY);
+
         networkCallbacks = new ConnectivityCallbacks(connectivityManager, connectivityChangesNotifier);
     }
 
@@ -96,6 +100,39 @@ public class ConnectivityCallbacksTest {
         networkCallbacks.onLost(MISSING_NETWORK);
 
         thenNotifiesMerlinServiceOfMissingNetwork();
+    }
+
+    @Test
+    public void givenCannotNotify_whenNetworkIsAvailable_thenNeverNotifiesConnectivityChangeEvent() {
+        given(connectivityChangesNotifier.canNotify()).willReturn(CANNOT_NOTIFY);
+
+        networkCallbacks.onAvailable(MISSING_NETWORK);
+
+        InOrder inOrder = inOrder(connectivityChangesNotifier);
+        inOrder.verify(connectivityChangesNotifier).canNotify();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void givenCannotNotify_whenLosingNetwork_thenNeverNotifiesConnectivityChangeEvent() {
+        given(connectivityChangesNotifier.canNotify()).willReturn(CANNOT_NOTIFY);
+
+        networkCallbacks.onLosing(MISSING_NETWORK, MAX_MS_TO_LIVE);
+
+        InOrder inOrder = inOrder(connectivityChangesNotifier);
+        inOrder.verify(connectivityChangesNotifier).canNotify();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void givenCannotNotify_whenNetworkIsLost_thenNeverNotifiesConnectivityChangeEvent() {
+        given(connectivityChangesNotifier.canNotify()).willReturn(CANNOT_NOTIFY);
+
+        networkCallbacks.onLost(MISSING_NETWORK);
+
+        InOrder inOrder = inOrder(connectivityChangesNotifier);
+        inOrder.verify(connectivityChangesNotifier).canNotify();
+        inOrder.verifyNoMoreInteractions();
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)

--- a/core/src/test/java/com/novoda/merlin/receiver/ConnectivityChangesRegisterTest.java
+++ b/core/src/test/java/com/novoda/merlin/receiver/ConnectivityChangesRegisterTest.java
@@ -36,7 +36,7 @@ public class ConnectivityChangesRegisterTest {
     @Mock
     private AndroidVersion androidVersion;
     @Mock
-    private MerlinService.ConnectivityChangesListener connectivityChangesListener;
+    private MerlinService.ConnectivityChangesNotifier connectivityChangesNotifier;
 
     private ConnectivityChangesRegister connectivityChangesRegister;
 
@@ -49,7 +49,7 @@ public class ConnectivityChangesRegisterTest {
     public void givenRegisteredBroadcastReceiver_whenBindingForASecondTime_thenOriginalBroadcastReceiverIsRegisteredAgain() {
         ArgumentCaptor<ConnectivityReceiver> broadcastReceiver = givenRegisteredBroadcastReceiver();
 
-        connectivityChangesRegister.register(connectivityChangesListener);
+        connectivityChangesRegister.register(connectivityChangesNotifier);
 
         verify(context, times(2)).registerReceiver(eq(broadcastReceiver.getValue()), refEq(new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION)));
     }
@@ -68,7 +68,7 @@ public class ConnectivityChangesRegisterTest {
     public void givenRegisteredMerlinNetworkCallbacks_whenBindingForASecondTime_thenOriginalNetworkCallbacksIsRegisteredAgain() {
         ArgumentCaptor<ConnectivityCallbacks> merlinNetworkCallback = givenRegisteredMerlinNetworkCallbacks();
 
-        connectivityChangesRegister.register(connectivityChangesListener);
+        connectivityChangesRegister.register(connectivityChangesNotifier);
 
         verify(connectivityManager, times(2)).registerNetworkCallback(refEq((new NetworkRequest.Builder()).build()), eq(merlinNetworkCallback.getValue()));
     }
@@ -85,7 +85,7 @@ public class ConnectivityChangesRegisterTest {
 
     private ArgumentCaptor<ConnectivityReceiver> givenRegisteredBroadcastReceiver() {
         given(androidVersion.isLollipopOrHigher()).willReturn(false);
-        connectivityChangesRegister.register(connectivityChangesListener);
+        connectivityChangesRegister.register(connectivityChangesNotifier);
         ArgumentCaptor<ConnectivityReceiver> argumentCaptor = ArgumentCaptor.forClass(ConnectivityReceiver.class);
         verify(context).registerReceiver(argumentCaptor.capture(), refEq(new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION)));
         return argumentCaptor;
@@ -94,7 +94,7 @@ public class ConnectivityChangesRegisterTest {
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     private ArgumentCaptor<ConnectivityCallbacks> givenRegisteredMerlinNetworkCallbacks() {
         given(androidVersion.isLollipopOrHigher()).willReturn(true);
-        connectivityChangesRegister.register(connectivityChangesListener);
+        connectivityChangesRegister.register(connectivityChangesNotifier);
         ArgumentCaptor<ConnectivityCallbacks> argumentCaptor = ArgumentCaptor.forClass(ConnectivityCallbacks.class);
         verify(connectivityManager).registerNetworkCallback(refEq((new NetworkRequest.Builder()).build()), argumentCaptor.capture());
         return argumentCaptor;

--- a/core/src/test/java/com/novoda/merlin/receiver/ConnectivityChangesRegisterTest.java
+++ b/core/src/test/java/com/novoda/merlin/receiver/ConnectivityChangesRegisterTest.java
@@ -8,6 +8,7 @@ import android.net.NetworkRequest;
 import android.os.Build;
 
 import com.novoda.merlin.service.AndroidVersion;
+import com.novoda.merlin.service.ConnectivityChangeEventExtractor;
 import com.novoda.merlin.service.MerlinService;
 
 import org.junit.Before;
@@ -37,12 +38,14 @@ public class ConnectivityChangesRegisterTest {
     private AndroidVersion androidVersion;
     @Mock
     private MerlinService.ConnectivityChangesNotifier connectivityChangesNotifier;
+    @Mock
+    private ConnectivityChangeEventExtractor extractor;
 
     private ConnectivityChangesRegister connectivityChangesRegister;
 
     @Before
     public void setUp() {
-        connectivityChangesRegister = new ConnectivityChangesRegister(context, connectivityManager, androidVersion);
+        connectivityChangesRegister = new ConnectivityChangesRegister(context, connectivityManager, androidVersion, extractor);
     }
 
     @Test

--- a/core/src/test/java/com/novoda/merlin/receiver/ConnectivityReceiverConnectivityChangeNotifierTest.java
+++ b/core/src/test/java/com/novoda/merlin/receiver/ConnectivityReceiverConnectivityChangeNotifierTest.java
@@ -48,7 +48,7 @@ public class ConnectivityReceiverConnectivityChangeNotifierTest {
 
         given(connectivityChangesNotifier.canNotify()).willReturn(CAN_NOTIFY);
 
-        given(merlinBinderRetriever.retrieveConnectivityChangesNotifierIfAvailable(context)).willReturn(connectivityChangesNotifier);
+        given(merlinBinderRetriever.retrieveConnectivityChangesNotifier(context)).willReturn(connectivityChangesNotifier);
         given(merlinsBeardCreator.createMerlinsBeard(context)).willReturn(merlinsBeard);
 
         notifier = new ConnectivityReceiverConnectivityChangeNotifier(merlinsBeardCreator, merlinBinderRetriever, eventCreator);
@@ -85,7 +85,7 @@ public class ConnectivityReceiverConnectivityChangeNotifierTest {
     @Test
     public void givenIntentWithConnectivityAction_butNullBinder_whenNotifying_thenNeverNotifiesOfConnectivityChangeEvent() {
         Intent intent = givenIntentWithConnectivityAction();
-        given(merlinBinderRetriever.retrieveConnectivityChangesNotifierIfAvailable(context)).willReturn(null);
+        given(merlinBinderRetriever.retrieveConnectivityChangesNotifier(context)).willReturn(null);
 
         notifier.notify(context, intent);
 
@@ -95,7 +95,7 @@ public class ConnectivityReceiverConnectivityChangeNotifierTest {
     @Test
     public void givenIntentWithConnectivityAction_butIncorrectBinder_whenNotifying_thenNeverNotifiesOfConnectivityChangeEvent() {
         Intent intent = givenIntentWithConnectivityAction();
-        given(merlinBinderRetriever.retrieveConnectivityChangesNotifierIfAvailable(context)).willReturn(incorrectBinder());
+        given(merlinBinderRetriever.retrieveConnectivityChangesNotifier(context)).willReturn(incorrectBinder());
 
         notifier.notify(context, intent);
 

--- a/core/src/test/java/com/novoda/merlin/receiver/ConnectivityReceiverTest.java
+++ b/core/src/test/java/com/novoda/merlin/receiver/ConnectivityReceiverTest.java
@@ -22,7 +22,7 @@ public class ConnectivityReceiverTest {
     @Mock
     private Intent intent;
     @Mock
-    private ConnectivityChangeNotifier notifier;
+    private ConnectivityReceiverConnectivityChangeNotifier notifier;
 
     private ConnectivityReceiver connectivityReceiver;
 

--- a/core/src/test/java/com/novoda/merlin/service/ConnectivityChangeEventExtractorTest.java
+++ b/core/src/test/java/com/novoda/merlin/service/ConnectivityChangeEventExtractorTest.java
@@ -1,0 +1,74 @@
+package com.novoda.merlin.service;
+
+import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkInfo;
+import android.os.Build;
+import android.support.annotation.RequiresApi;
+
+import com.novoda.merlin.receiver.ConnectivityChangeEvent;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+public class ConnectivityChangeEventExtractorTest {
+
+    private static final boolean CONNECTED = true;
+
+    private static final String ANY_REASON = "reason";
+    private static final String ANY_EXTRA_INFO = "extra info";
+
+    private static final Network ANY_NETWORK = mock(Network.class);
+    private static final NetworkInfo UNAVAILABLE_NETWORK_INFO = null;
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private ConnectivityManager connectivityManager;
+    @Mock
+    private NetworkInfo networkInfo;
+
+    private ConnectivityChangeEventExtractor eventExtractor;
+
+    @Before
+    public void setUp() {
+        given(networkInfo.isConnected()).willReturn(CONNECTED);
+        given(networkInfo.getReason()).willReturn(ANY_REASON);
+        given(networkInfo.getExtraInfo()).willReturn(ANY_EXTRA_INFO);
+
+        eventExtractor = new ConnectivityChangeEventExtractor(connectivityManager);
+    }
+
+    @Test
+    public void givenNetworkInfo_whenExtracting_thenReturnsConnectivityChangeEvent() {
+        given(connectivityManager.getNetworkInfo(ANY_NETWORK)).willReturn(networkInfo);
+
+        ConnectivityChangeEvent connectivityChangeEvent = eventExtractor.extractFrom(ANY_NETWORK);
+
+        assertThat(connectivityChangeEvent).isEqualTo(ConnectivityChangeEvent.createWithNetworkInfoChangeEvent(
+                CONNECTED,
+                ANY_EXTRA_INFO,
+                ANY_REASON
+        ));
+    }
+
+    @Test
+    public void givenNetworkInfoIsUnavailable_whenExtracting_thenReturnsConnectivityChangeEventWithoutConnection() {
+        given(connectivityManager.getNetworkInfo(ANY_NETWORK)).willReturn(UNAVAILABLE_NETWORK_INFO);
+
+        ConnectivityChangeEvent connectivityChangeEvent = eventExtractor.extractFrom(ANY_NETWORK);
+
+        assertThat(connectivityChangeEvent).isEqualTo(ConnectivityChangeEvent.createWithoutConnection());
+    }
+
+}

--- a/core/src/test/java/com/novoda/merlin/service/MerlinServiceTest.java
+++ b/core/src/test/java/com/novoda/merlin/service/MerlinServiceTest.java
@@ -86,14 +86,14 @@ public class MerlinServiceTest {
 
         localBinder.onBindComplete();
 
-        verify(connectivityChangesRegister).register(any(MerlinService.ConnectivityChangesListener.class));
+        verify(connectivityChangesRegister).register(any(MerlinService.ConnectivityChangesNotifier.class));
     }
 
     @Test
     public void givenRegisteredMerlinService_whenConnectivityChangeOccurs_thenNotifiesForwarder() {
-        MerlinService.ConnectivityChangesListener connectivityChangesListener = givenRegisteredMerlinService();
+        MerlinService.ConnectivityChangesNotifier connectivityChangesNotifier = givenRegisteredMerlinService();
 
-        connectivityChangesListener.onConnectivityChanged(ANY_CONNECTIVITY_CHANGE_EVENT);
+        connectivityChangesNotifier.notify(ANY_CONNECTIVITY_CHANGE_EVENT);
 
         verify(connectivityChangesForwarder).forward(ANY_CONNECTIVITY_CHANGE_EVENT);
     }
@@ -131,10 +131,10 @@ public class MerlinServiceTest {
         return binder;
     }
 
-    private MerlinService.ConnectivityChangesListener givenRegisteredMerlinService() {
+    private MerlinService.ConnectivityChangesNotifier givenRegisteredMerlinService() {
         MerlinService.LocalBinder localBinder = givenBoundMerlinService();
         localBinder.onBindComplete();
-        ArgumentCaptor<MerlinService.ConnectivityChangesListener> argumentCaptor = ArgumentCaptor.forClass(MerlinService.ConnectivityChangesListener.class);
+        ArgumentCaptor<MerlinService.ConnectivityChangesNotifier> argumentCaptor = ArgumentCaptor.forClass(MerlinService.ConnectivityChangesNotifier.class);
         verify(connectivityChangesRegister).register(argumentCaptor.capture());
         return argumentCaptor.getValue();
     }


### PR DESCRIPTION
## Problem
As per issue #149, there is a `NullPointerException` being thrown when the `ConnectivityManager` calls to the `ConnectivityCallbacks` but the `MerlinService` has already been killed. 

When removing the `ConnectivityCallbacks` from the `ConnectivityManager` it is managed in a `HandlerThread`. If we a `ConnectivityChangeEvent` in the meantime we can get into the state where the `Service` has been killed but the `ConnectivityCallbacks` are still referenced in memory and so we try to pass it off to the `Service`. 

This doesn't occur on devices lower than `Lollipop` because we use a different notification mechanism.

Here's the Stacktrace:
```
FATAL EXCEPTION: ConnectivityManager
                                                                     Process: com.taskpath.routes, PID: 13791
                                                                     java.lang.NullPointerException: Attempt to invoke virtual method 'void com.novoda.merlin.service.ConnectivityChangesForwarder.forward(com.novoda.merlin.receiver.ConnectivityChangeEvent)' on a null object reference
                                                                         at com.novoda.merlin.service.MerlinService$1.onConnectivityChanged(MerlinService.java:66)
                                                                         at com.novoda.merlin.receiver.ConnectivityCallbacks.notifyMerlinService(ConnectivityCallbacks.java:46)
                                                                         at com.novoda.merlin.receiver.ConnectivityCallbacks.onLost(ConnectivityCallbacks.java:34)
                                                                         at android.net.ConnectivityManager$CallbackHandler.handleMessage(ConnectivityManager.java:2425)
                                                                         at android.os.Handler.dispatchMessage(Handler.java:102)
                                                                         at android.os.Looper.loop(Looper.java:168)
                                                                         at android.os.HandlerThread.run(HandlerThread.java:61)
```

## Solution
Align the notification system for both connectivity change mechanisms. All calls to the `MerlinService` are now ONLY done through the `MerlinService.LocalBinder`. For creation we use the `LocalBinder` for all **notifications** we use the attached interface `ConnectivityChangesNotifier`. All classes that receive system network state changes are expected to call `canNotify` and `notify` to ensure that the `Service` is able to handle the state changes.

`ConnectivityCallbacks` receives and passes information back to the `ConnectivityChangesNotifier`, a collaborator on this class is responsible for **extracting** the required `NetworkInfo` from the `Network`.

### Test(s) added
Yes, to the extractor. In addition to updating all other tests with the new flow change.

### Screenshots
No UI changes.

### Paired with
Nobody.
