### PR TITLE
Add guard statement against null connection when unbinding

### DIFF
--- a/core/src/main/java/com/novoda/merlin/service/MerlinServiceBinder.java
+++ b/core/src/main/java/com/novoda/merlin/service/MerlinServiceBinder.java
@@ -46,7 +46,7 @@ public class MerlinServiceBinder {
     }
 
     public void unbind() {
-        if (MerlinService.isBound()) {
+        if (MerlinService.isBound() && merlinServiceConnection != null) {
             context.unbindService(merlinServiceConnection);
             context.stopService(new Intent(context, MerlinService.class));
             merlinServiceConnection = null;


### PR DESCRIPTION
## Problem
In the process of resolving issue #149, it appears that the raiser has seen another crash around a `null` connection when the service is being unbound.

## Solution
Add a guard statement to the `unbind` that will prevent unbinding a null reference `connection`.

### Test(s) added
No. Want to ship this and test on the raisers live app.

### Screenshots
No UI changes.

### Paired with
Nobody.
