### PR TITLE
MER-157/Runtime crash on clearing registerables

### DIFF
--- a/core/src/main/java/com/novoda/merlin/registerable/Registrar.java
+++ b/core/src/main/java/com/novoda/merlin/registerable/Registrar.java
@@ -1,5 +1,7 @@
 package com.novoda.merlin.registerable;
 
+import android.support.annotation.Nullable;
+
 import com.novoda.merlin.Merlin;
 import com.novoda.merlin.MerlinException;
 import com.novoda.merlin.registerable.bind.Bindable;
@@ -8,8 +10,11 @@ import com.novoda.merlin.registerable.disconnection.Disconnectable;
 
 public class Registrar {
 
+    @Nullable
     private final Register<Connectable> connectables;
+    @Nullable
     private final Register<Disconnectable> disconnectables;
+    @Nullable
     private final Register<Bindable> bindables;
 
     public Registrar(Register<Connectable> connectables, Register<Disconnectable> disconnectables, Register<Bindable> bindables) {
@@ -61,8 +66,16 @@ public class Registrar {
     }
 
     public void clearRegistrations() {
-        connectables.clear();
-        disconnectables.clear();
-        bindables.clear();
+        if (connectables != null) {
+            connectables.clear();
+        }
+
+        if (disconnectables != null) {
+            disconnectables.clear();
+        }
+
+        if (bindables != null) {
+            bindables.clear();
+        }
     }
 }

--- a/core/src/test/java/com/novoda/merlin/registerable/RegistrarTest.java
+++ b/core/src/test/java/com/novoda/merlin/registerable/RegistrarTest.java
@@ -12,8 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 public class RegistrarTest {
 
@@ -92,6 +91,33 @@ public class RegistrarTest {
         verify(connectables).clear();
         verify(disconnectables).clear();
         verify(bindables).clear();
+    }
+
+    @Test
+    public void givenMissingConnectables_whenClearingRegistrations_thenDoesNothing() {
+        registrar = new Registrar(null, disconnectables, bindables);
+
+        registrar.clearRegistrations();
+
+        verifyZeroInteractions(connectables);
+    }
+
+    @Test
+    public void givenMissingDisconnectables_whenClearingRegistrations_thenDoesNothing() {
+        registrar = new Registrar(connectables, null, bindables);
+
+        registrar.clearRegistrations();
+
+        verifyZeroInteractions(disconnectables);
+    }
+
+    @Test
+    public void givenMissingBindables_whenClearingRegistrations_thenDoesNothing() {
+        registrar = new Registrar(connectables, disconnectables, null);
+
+        registrar.clearRegistrations();
+
+        verifyZeroInteractions(bindables);
     }
 
 }


### PR DESCRIPTION
## Problem
Fix for the crash reported in #157. Registerables are always attempted to be cleared even when a client has not registered for that particular brand of registerable 😬 

## Solution
Highlight `Nullable` fields with an annotation and perform a null check before attempting to clear registerables. 

### Test(s) added
Fixed using TDD.

### Paired with
Nobody.
