### PR TITLE
ConnectivityChangesForwarder NullPointer

### DIFF
--- a/core/src/main/java/com/novoda/merlin/MerlinService.java
+++ b/core/src/main/java/com/novoda/merlin/MerlinService.java
@@ -77,7 +77,11 @@ public class MerlinService extends Service {
             if (!canNotify()) {
                 throw new IllegalStateException("You must call canNotify() before calling notify(ConnectivityChangeEvent)");
             }
-            MerlinService.this.connectivityChangesForwarder.forward(connectivityChangeEvent);
+
+            // Workaround for https://github.com/novoda/merlin/issues/163, further work required.
+            if (MerlinService.this.connectivityChangesForwarder != null) {
+                MerlinService.this.connectivityChangesForwarder.forward(connectivityChangeEvent);
+            }
         }
 
         void setConnectivityChangesRegister(ConnectivityChangesRegister connectivityChangesRegister) {


### PR DESCRIPTION
## Problem
This issue is detailed in #163 `NullPointerException` when attempting to forward statuses from the `MerlinService`. 

## Solution
⚠️ This is a patch only. This will stop the library from outright crashing but may swallow certain network statuses, preventing the client from being notified when more than a single `Merlin` instance is used. As per the discussion in #163 we will continue to work on a more comprehensive solution after this is shipped. 

### Test(s) added
No, just manual testing.

### Paired with
@niltsiar for a great discussion and @ClarkXP for providing a reproducible demo ❤️ 
