### PR TITLE
Multi activity demo

### DIFF
--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -6,10 +6,10 @@
   android:versionName="0.3-SNAPSHOT">
 
   <application
-    android:theme="@style/AppTheme"
     android:allowBackup="false"
     android:icon="@mipmap/ic_launcher"
     android:label="Merlin demo"
+    android:theme="@style/AppTheme"
     tools:ignore="GoogleAppIndexingWarning">
 
     <activity

--- a/demo/src/main/java/com/novoda/merlin/demo/presentation/DemoActivity.java
+++ b/demo/src/main/java/com/novoda/merlin/demo/presentation/DemoActivity.java
@@ -1,5 +1,6 @@
 package com.novoda.merlin.demo.presentation;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
 
@@ -32,6 +33,7 @@ public class DemoActivity extends MerlinActivity implements Connectable, Disconn
         findViewById(R.id.wifi_connected).setOnClickListener(wifiConnectedOnClick);
         findViewById(R.id.mobile_connected).setOnClickListener(mobileConnectedOnClick);
         findViewById(R.id.network_subtype).setOnClickListener(networkSubtypeOnClick);
+        findViewById(R.id.next_activity).setOnClickListener(nextActivityOnClick);
     }
 
     private final View.OnClickListener networkStatusOnClick = new View.OnClickListener() {
@@ -74,6 +76,15 @@ public class DemoActivity extends MerlinActivity implements Connectable, Disconn
         @Override
         public void onClick(View view) {
             networkStatusDisplayer.displayNetworkSubtype(viewToAttachDisplayerTo);
+        }
+    };
+
+    private final View.OnClickListener nextActivityOnClick = new View.OnClickListener() {
+
+        @Override
+        public void onClick(View view) {
+            Intent intent = new Intent(getApplicationContext(), DemoActivity.class);
+            startActivity(intent);
         }
     };
 

--- a/demo/src/main/java/com/novoda/merlin/demo/presentation/HomeActivity.java
+++ b/demo/src/main/java/com/novoda/merlin/demo/presentation/HomeActivity.java
@@ -1,13 +1,13 @@
 package com.novoda.merlin.demo.presentation;
 
-import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 
 import com.novoda.merlin.demo.R;
 
-public class HomeActivity extends Activity {
+public class HomeActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/demo/src/main/java/com/novoda/merlin/demo/presentation/RxJava2DemoActivity.java
+++ b/demo/src/main/java/com/novoda/merlin/demo/presentation/RxJava2DemoActivity.java
@@ -1,14 +1,15 @@
 package com.novoda.merlin.demo.presentation;
 
 import android.app.Activity;
+import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
 
+import com.novoda.merlin.MerlinFlowable;
 import com.novoda.merlin.MerlinsBeard;
 import com.novoda.merlin.NetworkStatus;
 import com.novoda.merlin.demo.R;
 import com.novoda.merlin.demo.connectivity.display.NetworkStatusDisplayer;
-import com.novoda.merlin.MerlinFlowable;
 
 import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.CompositeDisposable;
@@ -35,6 +36,7 @@ public class RxJava2DemoActivity extends Activity {
         findViewById(R.id.wifi_connected).setOnClickListener(wifiConnectedOnClick);
         findViewById(R.id.mobile_connected).setOnClickListener(mobileConnectedOnClick);
         findViewById(R.id.network_subtype).setOnClickListener(networkSubtypeOnClick);
+        findViewById(R.id.next_activity).setOnClickListener(nextActivityOnClick);
     }
 
     private final View.OnClickListener networkStatusOnClick = new View.OnClickListener() {
@@ -77,6 +79,15 @@ public class RxJava2DemoActivity extends Activity {
         @Override
         public void onClick(View view) {
             networkStatusDisplayer.displayNetworkSubtype(viewToAttachDisplayerTo);
+        }
+    };
+
+    private final View.OnClickListener nextActivityOnClick = new View.OnClickListener() {
+
+        @Override
+        public void onClick(View view) {
+            Intent intent = new Intent(getApplicationContext(), RxJava2DemoActivity.class);
+            startActivity(intent);
         }
     };
 

--- a/demo/src/main/java/com/novoda/merlin/demo/presentation/RxJava2DemoActivity.java
+++ b/demo/src/main/java/com/novoda/merlin/demo/presentation/RxJava2DemoActivity.java
@@ -1,8 +1,8 @@
 package com.novoda.merlin.demo.presentation;
 
-import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 
 import com.novoda.merlin.MerlinFlowable;
@@ -16,7 +16,7 @@ import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Consumer;
 
-public class RxJava2DemoActivity extends Activity {
+public class RxJava2DemoActivity extends AppCompatActivity {
 
     private NetworkStatusDisplayer networkStatusDisplayer;
     private MerlinsBeard merlinsBeard;

--- a/demo/src/main/java/com/novoda/merlin/demo/presentation/RxJavaDemoActivity.java
+++ b/demo/src/main/java/com/novoda/merlin/demo/presentation/RxJavaDemoActivity.java
@@ -1,8 +1,8 @@
 package com.novoda.merlin.demo.presentation;
 
-import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 
 import com.novoda.merlin.MerlinObservable;
@@ -15,7 +15,7 @@ import rx.Subscription;
 import rx.functions.Action1;
 import rx.subscriptions.CompositeSubscription;
 
-public class RxJavaDemoActivity extends Activity {
+public class RxJavaDemoActivity extends AppCompatActivity {
 
     private NetworkStatusDisplayer networkStatusDisplayer;
     private MerlinsBeard merlinsBeard;

--- a/demo/src/main/java/com/novoda/merlin/demo/presentation/RxJavaDemoActivity.java
+++ b/demo/src/main/java/com/novoda/merlin/demo/presentation/RxJavaDemoActivity.java
@@ -1,14 +1,15 @@
 package com.novoda.merlin.demo.presentation;
 
 import android.app.Activity;
+import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
 
+import com.novoda.merlin.MerlinObservable;
 import com.novoda.merlin.MerlinsBeard;
 import com.novoda.merlin.NetworkStatus;
 import com.novoda.merlin.demo.R;
 import com.novoda.merlin.demo.connectivity.display.NetworkStatusDisplayer;
-import com.novoda.merlin.MerlinObservable;
 
 import rx.Subscription;
 import rx.functions.Action1;
@@ -34,6 +35,7 @@ public class RxJavaDemoActivity extends Activity {
         findViewById(R.id.wifi_connected).setOnClickListener(wifiConnectedOnClick);
         findViewById(R.id.mobile_connected).setOnClickListener(mobileConnectedOnClick);
         findViewById(R.id.network_subtype).setOnClickListener(networkSubtypeOnClick);
+        findViewById(R.id.next_activity).setOnClickListener(nextActivityOnClick);
     }
 
     private final View.OnClickListener networkStatusOnClick = new View.OnClickListener() {
@@ -76,6 +78,15 @@ public class RxJavaDemoActivity extends Activity {
         @Override
         public void onClick(View view) {
             networkStatusDisplayer.displayNetworkSubtype(viewToAttachDisplayerTo);
+        }
+    };
+
+    private final View.OnClickListener nextActivityOnClick = new View.OnClickListener() {
+
+        @Override
+        public void onClick(View view) {
+            Intent intent = new Intent(getApplicationContext(), RxJavaDemoActivity.class);
+            startActivity(intent);
         }
     };
 

--- a/demo/src/main/java/com/novoda/merlin/demo/presentation/base/MerlinActivity.java
+++ b/demo/src/main/java/com/novoda/merlin/demo/presentation/base/MerlinActivity.java
@@ -4,11 +4,11 @@ import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 
-import com.novoda.merlin.Merlin;
 import com.novoda.merlin.Bindable;
 import com.novoda.merlin.Connectable;
 import com.novoda.merlin.Disconnectable;
 import com.novoda.merlin.Logger;
+import com.novoda.merlin.Merlin;
 
 public abstract class MerlinActivity extends AppCompatActivity {
 

--- a/demo/src/main/res/layout/home.xml
+++ b/demo/src/main/res/layout/home.xml
@@ -1,31 +1,37 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
   android:layout_width="match_parent"
-  android:layout_height="match_parent">
+  android:layout_height="match_parent"
+  android:orientation="vertical"
+  android:paddingTop="@dimen/content_padding_top">
+
+  <ImageView
+    android:id="@+id/merlin_logo"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center_horizontal"
+    android:layout_marginBottom="@dimen/content_margin_bottom"
+    android:contentDescription="@string/merlin_logo"
+    android:src="@mipmap/ic_launcher" />
 
   <Button
     android:id="@+id/demo_launch_button"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_centerHorizontal="true"
-    android:layout_centerVertical="true"
+    android:layout_gravity="center_horizontal"
     android:text="@string/demo_launch_button" />
 
   <Button
     android:id="@+id/rx_java_demo_launch_button"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_below="@id/demo_launch_button"
-    android:layout_centerHorizontal="true"
-    android:layout_centerVertical="true"
+    android:layout_gravity="center_horizontal"
     android:text="@string/rx_java_demo_launch_button" />
 
   <Button
     android:id="@+id/rx_java2_demo_launch_button"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_below="@id/rx_java_demo_launch_button"
-    android:layout_centerHorizontal="true"
-    android:layout_centerVertical="true"
+    android:layout_gravity="center_horizontal"
     android:text="@string/rx_java2_demo_launch_button" />
 
-</RelativeLayout>
+</LinearLayout>

--- a/demo/src/main/res/layout/main.xml
+++ b/demo/src/main/res/layout/main.xml
@@ -34,4 +34,11 @@
     android:layout_gravity="center_horizontal"
     android:text="@string/get_network_subtype" />
 
+  <Button
+    android:id="@+id/next_activity"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center_horizontal"
+    android:text="@string/next_activity" />
+
 </LinearLayout>

--- a/demo/src/main/res/layout/main.xml
+++ b/demo/src/main/res/layout/main.xml
@@ -6,6 +6,14 @@
   android:orientation="vertical"
   android:paddingTop="@dimen/content_padding_top">
 
+  <ImageView
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center_horizontal"
+    android:layout_marginBottom="@dimen/content_margin_bottom"
+    android:contentDescription="@string/merlin_logo"
+    android:src="@mipmap/ic_launcher" />
+
   <Button
     android:id="@+id/current_status"
     android:layout_width="wrap_content"

--- a/demo/src/main/res/values/dimens.xml
+++ b/demo/src/main/res/values/dimens.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <dimen name="content_padding_top">20dp</dimen>
+  <dimen name="content_margin_bottom">10dp</dimen>
   <dimen name="snackbar_minimum_height">48dp</dimen>
   <dimen name="snackbar_text_size">18sp</dimen>
 </resources>

--- a/demo/src/main/res/values/strings.xml
+++ b/demo/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
   <string name="is_wifi_connected">Is connected to Wi-Fi</string>
   <string name="is_mobile_connected">Is connected to mobile network</string>
   <string name="get_network_subtype">Get network subtype</string>
+  <string name="next_activity">Next activity</string>
 
   <string name="demo_launch_button">Launch demo</string>
   <string name="rx_java_demo_launch_button">Launch RxJava demo</string>

--- a/demo/src/main/res/values/strings.xml
+++ b/demo/src/main/res/values/strings.xml
@@ -25,5 +25,6 @@
   <string name="demo_launch_button">Launch demo</string>
   <string name="rx_java_demo_launch_button">Launch RxJava demo</string>
   <string name="rx_java2_demo_launch_button">Launch RxJava2 demo</string>
+  <string name="merlin_logo">Merlin logo</string>
 
 </resources>


### PR DESCRIPTION
## Problem
In #163 we created a patch to solve a `NullPointerException` that can occur when creating multiple instances of `Merlin` and navigating between activities. There's a lot of detail about this bug in the ticket so I would suggest reading through it if you are interested. As part of that ticket we raised a ticket to create a demo where we could navigate to additional activities to test this scenario, see #166 

## Solution
Add a button that just navigates to the same activity, allowing us to stack indefinitely if we want. This was the easiest solution and will allow us to stress test the demo application. I've also made the other demo activities extend from the `AppCompatActivity` as I noticed they were missing the header.

I also added our logo to the landing and demo screens 😄 

## Next Steps
Revert the change that was introduced in #164 and provide a more comprehensive fix. 

### Screen Capture

Landing | Demo
--- | --- 
![launch](https://user-images.githubusercontent.com/3380092/46068798-e3ac8680-c171-11e8-86ae-f3e93cddb575.png) | ![demo](https://user-images.githubusercontent.com/3380092/46068796-e313f000-c171-11e8-98af-73dcb9cff366.png)

### Paired with
Nobody. 
