### PR TITLE
MER-171/IllegalStateException when attempting to notify

### DIFF
--- a/core/src/main/java/com/novoda/merlin/MerlinService.java
+++ b/core/src/main/java/com/novoda/merlin/MerlinService.java
@@ -74,13 +74,11 @@ public class MerlinService extends Service {
 
         @Override
         public void notify(ConnectivityChangeEvent connectivityChangeEvent) {
-            if (!canNotify()) {
-                throw new IllegalStateException("You must call canNotify() before calling notify(ConnectivityChangeEvent)");
-            }
-
-            // Workaround for https://github.com/novoda/merlin/issues/163, further work required.
-            if (MerlinService.this.connectivityChangesForwarder != null) {
+            // Workaround for https://github.com/novoda/merlin/issues/163 & 171, further work required.
+            if (canNotify() && MerlinService.this.connectivityChangesForwarder != null) {
                 MerlinService.this.connectivityChangesForwarder.forward(connectivityChangeEvent);
+            } else {
+                Logger.w("notify event dropped due to inconsistent service state");
             }
         }
 

--- a/core/src/test/java/com/novoda/merlin/MerlinServiceTest.java
+++ b/core/src/test/java/com/novoda/merlin/MerlinServiceTest.java
@@ -10,7 +10,10 @@ import org.mockito.ArgumentCaptor;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class MerlinServiceTest {
 
@@ -109,6 +112,27 @@ public class MerlinServiceTest {
         binder.onBindComplete();
 
         verifyZeroInteractions(connectivityChangesRegister);
+        verifyZeroInteractions(connectivityChangesForwarder);
+    }
+
+
+    @Test
+    public void givenUnboundService_whenNotifying_thenDoesNotForwardEvent() {
+        MerlinService.LocalBinder localBinder = givenBoundMerlinService();
+
+        merlinService.onUnbind(null);
+        localBinder.notify(ANY_CONNECTIVITY_CHANGE_EVENT);
+
+        verifyZeroInteractions(connectivityChangesForwarder);
+    }
+
+    @Test
+    public void givenNullForwarder_whenNotifying_thenDoesNotForwardEvent() {
+        MerlinService.LocalBinder localBinder = givenBoundMerlinService();
+        localBinder.setConnectivityChangesForwarder(null);
+
+        localBinder.notify(ANY_CONNECTIVITY_CHANGE_EVENT);
+
         verifyZeroInteractions(connectivityChangesForwarder);
     }
 

--- a/core/src/test/java/com/novoda/merlin/MerlinServiceTest.java
+++ b/core/src/test/java/com/novoda/merlin/MerlinServiceTest.java
@@ -115,7 +115,6 @@ public class MerlinServiceTest {
         verifyZeroInteractions(connectivityChangesForwarder);
     }
 
-
     @Test
     public void givenUnboundService_whenNotifying_thenDoesNotForwardEvent() {
         MerlinService.LocalBinder localBinder = givenBoundMerlinService();


### PR DESCRIPTION
## Problem

Addresses #171 

We've been aggressively throwing when the service is in an inconsistent state, however this exception is not catchable from the client side as it happens as part of the background service.

## Solution

To no longer crash and instead `Log.warn`.

### Test(s) added

Yep around the cases where the forwarding is ignored (and no longer crashes)

### Paired with

Nobody