### PR TITLE
Disconnect when Http connection errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 allprojects {
-    version = '1.2.0'
+    version = '1.2.1'
     repositories {
         mavenCentral()
         google()

--- a/core/src/main/java/com/novoda/merlin/HttpRequestMaker.java
+++ b/core/src/main/java/com/novoda/merlin/HttpRequestMaker.java
@@ -11,8 +11,9 @@ class HttpRequestMaker implements RequestMaker {
 
     @Override
     public Request head(Endpoint endpoint) {
+        HttpURLConnection urlConnection = null;
         try {
-            HttpURLConnection urlConnection = connectTo(endpoint);
+            urlConnection = connectTo(endpoint);
             urlConnection.setRequestProperty("Accept-Encoding", "");
 
             setConnectionToHeadRequest(urlConnection);
@@ -21,6 +22,10 @@ class HttpRequestMaker implements RequestMaker {
             return new MerlinHttpRequest(urlConnection);
         } catch (IOException e) {
             throw new RequestException(e);
+        } finally {
+            if (urlConnection != null) {
+                urlConnection.disconnect();
+            }
         }
     }
 
@@ -55,7 +60,6 @@ class HttpRequestMaker implements RequestMaker {
                 request.disconnect();
             }
         }
-
     }
 
 }


### PR DESCRIPTION
## Problem
We are receiving some warnings in client applications for not closing the request from `Merlin` 😬 After taking a look at the `HttpRequestMaker` I noticed that we only close the request when we retrieve a response code. However we can throw in the earlier code and we do not explicitly close in this case.

## Solution
Ensure that we close when we receive any errors  during the setup. 

### Paired with
Nobody.
