### PR TITLE
V2 library module

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -21,6 +21,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation project(':library')
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,4 +1,6 @@
 apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion 28
@@ -22,6 +24,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.android.support:appcompat-v7:28.0.0'
     testImplementation 'junit:junit:4.12'
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,0 +1,27 @@
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion 28
+
+    defaultConfig {
+        minSdkVersion 19
+        targetSdkVersion 28
+        versionCode 1
+        versionName "1.0"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+
+}
+
+dependencies {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    testImplementation 'junit:junit:4.12'
+}

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.novoda.merlin"/>

--- a/library/src/main/java/com/novoda/merlin/contracts/Callbacks.kt
+++ b/library/src/main/java/com/novoda/merlin/contracts/Callbacks.kt
@@ -1,0 +1,15 @@
+package com.novoda.merlin.contracts
+
+interface Callback
+
+interface ConnectionCallback : Callback {
+    fun onConnect()
+}
+
+interface DisconnectionCallback : Callback {
+    fun onDisconnect()
+}
+
+interface BindingCallback : Callback {
+    fun onBind()
+}

--- a/library/src/main/java/com/novoda/merlin/contracts/HostPing.kt
+++ b/library/src/main/java/com/novoda/merlin/contracts/HostPing.kt
@@ -1,0 +1,20 @@
+package com.novoda.merlin.contracts
+
+import java.net.URL
+
+interface Endpoint {
+
+    fun asURL(): URL
+
+}
+
+interface ResponseCodeValidator {
+
+    fun isResponseCodeValid(responseCode: Int): Boolean
+
+    class CaptivePortalResponseCodeValidator : ResponseCodeValidator {
+        override fun isResponseCodeValid(responseCode: Int): Boolean {
+            return responseCode == 204
+        }
+    }
+}

--- a/library/src/main/java/com/novoda/merlin/contracts/Merlin.kt
+++ b/library/src/main/java/com/novoda/merlin/contracts/Merlin.kt
@@ -1,0 +1,32 @@
+package com.novoda.merlin.contracts
+
+interface Merlin {
+
+    fun setEndpoint(endpoint: Endpoint, responseCodeValidator: ResponseCodeValidator)
+
+    fun addConnectionCallback()
+
+    fun addDisconnectionCallback()
+
+    fun addBindingCallback()
+
+    interface Builder {
+
+        fun withConnectionCallbacks(): Builder
+
+        fun withDisconnectionCallbacks(): Builder
+
+        fun withBindingCallbacks(): Builder
+
+        fun withAllCallbacks(): Builder
+
+        fun withLogging(): Builder
+
+        fun withEndpoint(endpoint: Endpoint): Builder
+
+        fun withResponseCodeValidator(responseCodeValidator: ResponseCodeValidator): Builder
+
+        fun build(): Merlin
+    }
+
+}

--- a/library/src/main/java/com/novoda/merlin/contracts/MerlinsBeard.kt
+++ b/library/src/main/java/com/novoda/merlin/contracts/MerlinsBeard.kt
@@ -1,0 +1,17 @@
+package com.novoda.merlin.contracts
+
+interface MerlinsBeard {
+
+    fun isConnected(): Boolean
+
+    fun isConnectedToMobileNetwork(): Boolean
+
+    fun isConnectedToWifi(): Boolean
+
+    fun mobileNetworkSubtype(): String
+
+    fun hasInternetAccess(unit: Unit)
+
+    fun hasInternetAccess(): Boolean
+
+}

--- a/library/src/main/java/com/novoda/merlin/contracts/MerlinsBeard.kt
+++ b/library/src/main/java/com/novoda/merlin/contracts/MerlinsBeard.kt
@@ -1,5 +1,7 @@
 package com.novoda.merlin.contracts
 
+typealias InternetAccessCallback = (Boolean) -> Unit
+
 interface MerlinsBeard {
 
     fun isConnected(): Boolean
@@ -10,7 +12,7 @@ interface MerlinsBeard {
 
     fun mobileNetworkSubtype(): String
 
-    fun hasInternetAccess(unit: Unit)
+    fun hasInternetAccess(callback: InternetAccessCallback)
 
     fun hasInternetAccess(): Boolean
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':demo'
+include ':demo', ':library'


### PR DESCRIPTION
DO NOT MERGE, dependent on #187 

## Problem
Version 2 has a demo project but no `library` module for the important `merlin` code 

## Solution
Introduce a `library` module and add some baseline contracts. 

I opted for exposing the libraries contracts with public interfaces that exist in the `com.novoda.merlin.contracts` package. I might swap this to the `com.novoda.merlin` package and have all internal classes one layer deeper in `com.novoda.merlin.internal` to make it absolutely clear what is global and what is internal to the library. Opinions more than welcome 
