### PR TITLE
V2 MerlinsBeard

### DIFF
--- a/java-demo/src/main/java/com/novoda/java/demo/DemoActivity.java
+++ b/java-demo/src/main/java/com/novoda/java/demo/DemoActivity.java
@@ -16,39 +16,44 @@ public class DemoActivity extends CommonDemoActivity {
 
         currentStatus().setOnClickListener(view -> {
             if (merlinsBeard.isConnected()) {
-                Toast.makeText(this, "Connected", Toast.LENGTH_SHORT).show();
+                Toast.makeText(this, R.string.current_status_network_connected, Toast.LENGTH_SHORT).show();
             } else {
-                Toast.makeText(this, "Disconnected", Toast.LENGTH_SHORT).show();
+                Toast.makeText(this, R.string.current_status_network_disconnected, Toast.LENGTH_SHORT).show();
             }
         });
 
         hasInternetAccess().setOnClickListener(view -> {
             if (merlinsBeard.hasInternetAccess()) {
-                Toast.makeText(this, "Has internet access", Toast.LENGTH_SHORT).show();
+                Toast.makeText(this, R.string.has_internet_access_true, Toast.LENGTH_SHORT).show();
             } else {
-                Toast.makeText(this, "Does not have internet access", Toast.LENGTH_SHORT).show();
+                Toast.makeText(this, R.string.has_internet_access_false, Toast.LENGTH_SHORT).show();
             }
         });
 
         wifiConnected().setOnClickListener(view -> {
             if (merlinsBeard.isConnectedToWifi()) {
-                Toast.makeText(this, "Wifi connected", Toast.LENGTH_SHORT).show();
+                Toast.makeText(this, R.string.wifi_connected, Toast.LENGTH_SHORT).show();
             } else {
-                Toast.makeText(this, "Wifi disconnected", Toast.LENGTH_SHORT).show();
+                Toast.makeText(this, R.string.wifi_disconnected, Toast.LENGTH_SHORT).show();
             }
         });
 
         mobileConnected().setOnClickListener(view -> {
             if (merlinsBeard.isConnectedToMobileNetwork()) {
-                Toast.makeText(this, "Mobile connected", Toast.LENGTH_SHORT).show();
+                Toast.makeText(this, R.string.mobile_connected, Toast.LENGTH_SHORT).show();
             } else {
-                Toast.makeText(this, "Mobile disconnected", Toast.LENGTH_SHORT).show();
+                Toast.makeText(this, R.string.mobile_disconnected, Toast.LENGTH_SHORT).show();
             }
         });
 
         networkSubtype().setOnClickListener(view -> {
-            String message = "Network subtype: " + merlinsBeard.mobileNetworkSubtype();
-            Toast.makeText(this, message, Toast.LENGTH_SHORT).show();
+            String mobileNetworkSubtype = merlinsBeard.mobileNetworkSubtype();
+            if (mobileNetworkSubtype.isEmpty()) {
+                Toast.makeText(this, R.string.subtype_not_available, Toast.LENGTH_SHORT).show();
+            } else {
+                String message = getResources().getString(R.string.subtype_value, mobileNetworkSubtype);
+                Toast.makeText(this, message, Toast.LENGTH_SHORT).show();
+            }
         });
 
         nextActivity().setOnClickListener(view -> {

--- a/java-demo/src/main/java/com/novoda/java/demo/DemoActivity.java
+++ b/java-demo/src/main/java/com/novoda/java/demo/DemoActivity.java
@@ -1,8 +1,10 @@
 package com.novoda.java.demo;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.widget.Toast;
 import com.novoda.demo.resources.CommonDemoActivity;
+import com.novoda.merlin.contracts.MerlinsBeard;
 
 public class DemoActivity extends CommonDemoActivity {
 
@@ -10,11 +12,48 @@ public class DemoActivity extends CommonDemoActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        currentStatus().setOnClickListener(view -> Toast.makeText(this, "Network status", Toast.LENGTH_SHORT).show());
-        hasInternetAccess().setOnClickListener(view -> Toast.makeText(this, "Has internet access", Toast.LENGTH_SHORT).show());
-        wifiConnected().setOnClickListener(view -> Toast.makeText(this, "Wifi connected", Toast.LENGTH_SHORT).show());
-        mobileConnected().setOnClickListener(view -> Toast.makeText(this, "Mobile connected", Toast.LENGTH_SHORT).show());
-        networkSubtype().setOnClickListener(view -> Toast.makeText(this, "Network subtype", Toast.LENGTH_SHORT).show());
-        nextActivity().setOnClickListener(view -> Toast.makeText(this, "Navigate to next activity", Toast.LENGTH_SHORT).show());
+        MerlinsBeard merlinsBeard = MerlinsBeard.create(this);
+
+        currentStatus().setOnClickListener(view -> {
+            if (merlinsBeard.isConnected()) {
+                Toast.makeText(this, "Connected", Toast.LENGTH_SHORT).show();
+            } else {
+                Toast.makeText(this, "Disconnected", Toast.LENGTH_SHORT).show();
+            }
+        });
+
+        hasInternetAccess().setOnClickListener(view -> {
+            if (merlinsBeard.hasInternetAccess()) {
+                Toast.makeText(this, "Has internet access", Toast.LENGTH_SHORT).show();
+            } else {
+                Toast.makeText(this, "Does not have internet access", Toast.LENGTH_SHORT).show();
+            }
+        });
+
+        wifiConnected().setOnClickListener(view -> {
+            if (merlinsBeard.isConnectedToWifi()) {
+                Toast.makeText(this, "Wifi connected", Toast.LENGTH_SHORT).show();
+            } else {
+                Toast.makeText(this, "Wifi disconnected", Toast.LENGTH_SHORT).show();
+            }
+        });
+
+        mobileConnected().setOnClickListener(view -> {
+            if (merlinsBeard.isConnectedToMobileNetwork()) {
+                Toast.makeText(this, "Mobile connected", Toast.LENGTH_SHORT).show();
+            } else {
+                Toast.makeText(this, "Mobile disconnected", Toast.LENGTH_SHORT).show();
+            }
+        });
+
+        networkSubtype().setOnClickListener(view -> {
+            String message = "Network subtype: " + merlinsBeard.mobileNetworkSubtype();
+            Toast.makeText(this, message, Toast.LENGTH_SHORT).show();
+        });
+
+        nextActivity().setOnClickListener(view -> {
+            Intent intent = new Intent(getApplicationContext(), DemoActivity.class);
+            startActivity(intent);
+        });
     }
 }

--- a/kotlin-demo/build.gradle
+++ b/kotlin-demo/build.gradle
@@ -14,6 +14,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
 }
 
 dependencies {

--- a/kotlin-demo/src/main/java/com/novoda/kotlin/demo/DemoActivity.kt
+++ b/kotlin-demo/src/main/java/com/novoda/kotlin/demo/DemoActivity.kt
@@ -1,25 +1,61 @@
 package com.novoda.kotlin.demo
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
 import com.novoda.demo.resources.CommonDemoActivity
+import com.novoda.merlin.contracts.MerlinsBeard
+import kotlin.reflect.KFunction0
+
+typealias MerlinsBeardFunc = KFunction0<Boolean>
 
 class DemoActivity : CommonDemoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        currentStatus().onClick("Network status")
-        hasInternetAccess().onClick("Has internet access")
-        wifiConnected().onClick("Wifi connected")
-        mobileConnected().onClick("Mobile connected")
-        networkSubtype().onClick("Network subtype")
-        nextActivity().onClick("Navigate to next activity")
+        val merlinsBeard = MerlinsBeard.create(this)
+
+        currentStatus().onClick(
+            merlinsBeard::isConnected,
+            R.string.current_status_network_connected,
+            R.string.current_status_network_disconnected
+        )
+        hasInternetAccess().onClick(
+            merlinsBeard::hasInternetAccess,
+            R.string.has_internet_access_true,
+            R.string.has_internet_access_false
+        )
+        wifiConnected().onClick(
+            merlinsBeard::isConnectedToWifi,
+            R.string.wifi_connected,
+            R.string.wifi_disconnected
+        )
+        mobileConnected().onClick(
+            merlinsBeard::isConnectedToMobileNetwork,
+            R.string.mobile_connected,
+            R.string.mobile_disconnected
+        )
+        networkSubtype().onClick(merlinsBeard::mobileNetworkSubtype)
+        nextActivity().setOnClickListener {
+            startActivity(Intent(applicationContext, DemoActivity::class.java))
+        }
     }
 
-    private fun View.onClick(message: String) {
+    private fun View.onClick(
+        isPositive: MerlinsBeardFunc,
+        positiveMessage: Int,
+        negativeMessage: Int
+    ) {
         setOnClickListener {
+            val message = if (isPositive()) positiveMessage else negativeMessage
             Toast.makeText(this@DemoActivity, message, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun View.onClick(message: KFunction0<String>) {
+        setOnClickListener {
+            Toast.makeText(this@DemoActivity, message(), Toast.LENGTH_SHORT).show()
         }
     }
 }

--- a/kotlin-demo/src/main/java/com/novoda/kotlin/demo/DemoActivity.kt
+++ b/kotlin-demo/src/main/java/com/novoda/kotlin/demo/DemoActivity.kt
@@ -53,9 +53,16 @@ class DemoActivity : CommonDemoActivity() {
         }
     }
 
-    private fun View.onClick(message: KFunction0<String>) {
+    private fun View.onClick(subtype: KFunction0<String>) {
         setOnClickListener {
-            Toast.makeText(this@DemoActivity, message(), Toast.LENGTH_SHORT).show()
+            with(subtype()) {
+                if (this.isBlank()) {
+                    Toast.makeText(this@DemoActivity, R.string.subtype_not_available, Toast.LENGTH_SHORT).show()
+                } else {
+                    val message = resources.getString(R.string.subtype_value, this)
+                    Toast.makeText(this@DemoActivity, message, Toast.LENGTH_SHORT).show()
+                }
+            }
         }
     }
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -14,6 +14,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
 }
 
 dependencies {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -25,5 +25,4 @@ dependencies {
     testImplementation 'com.nhaarman:mockito-kotlin:1.5.0'
     testImplementation 'org.jetbrains.spek:spek-api:1.1.5'
     testImplementation 'org.jetbrains.spek:spek-junit-platform-engine:1.1.5'
-    testImplementation 'org.junit.platform:junit-platform-runner:1.0.0'
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -20,5 +20,10 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.android.support:appcompat-v7:28.0.0'
+    testImplementation "com.google.truth:truth:0.42"
     testImplementation 'junit:junit:4.12'
+    testImplementation 'com.nhaarman:mockito-kotlin:1.5.0'
+    testImplementation 'org.jetbrains.spek:spek-api:1.1.5'
+    testImplementation 'org.jetbrains.spek:spek-junit-platform-engine:1.1.5'
+    testImplementation 'org.junit.platform:junit-platform-runner:1.0.0'
 }

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,1 +1,4 @@
-<manifest package="com.novoda.merlin"/>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.novoda.merlin">
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+</manifest>

--- a/library/src/main/java/com/novoda/merlin/contracts/MerlinsBeard.kt
+++ b/library/src/main/java/com/novoda/merlin/contracts/MerlinsBeard.kt
@@ -1,8 +1,14 @@
 package com.novoda.merlin.contracts
 
+import android.net.ConnectivityManager
+import com.novoda.merlin.internal.AndroidVersion
+
 typealias InternetAccessCallback = (Boolean) -> Unit
 
 interface MerlinsBeard {
+
+    val connectivityManager: ConnectivityManager
+    val androidVersion: AndroidVersion
 
     fun isConnected(): Boolean
 

--- a/library/src/main/java/com/novoda/merlin/contracts/MerlinsBeard.kt
+++ b/library/src/main/java/com/novoda/merlin/contracts/MerlinsBeard.kt
@@ -1,5 +1,7 @@
 package com.novoda.merlin.contracts
 
+import android.annotation.SuppressLint
+import android.content.Context
 import android.net.ConnectivityManager
 import com.novoda.merlin.internal.AndroidVersion
 
@@ -22,4 +24,14 @@ interface MerlinsBeard {
 
     fun hasInternetAccess(): Boolean
 
+    companion object {
+        @SuppressLint("NewApi") // Compiles into static create method, there is no problem.
+        @JvmStatic
+        fun create(context: Context): MerlinsBeard {
+            val applicationContext = context.applicationContext
+            val connectivityManager =
+                applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+            return com.novoda.merlin.internal.MerlinsBeard(connectivityManager)
+        }
+    }
 }

--- a/library/src/main/java/com/novoda/merlin/internal/AndroidVersion.kt
+++ b/library/src/main/java/com/novoda/merlin/internal/AndroidVersion.kt
@@ -1,0 +1,9 @@
+package com.novoda.merlin.internal
+
+import android.os.Build
+
+class AndroidVersion(val androidVersion: Int = Build.VERSION.SDK_INT) {
+
+    fun isLollipopOrHigher(): Boolean = androidVersion >= Build.VERSION_CODES.LOLLIPOP
+
+}

--- a/library/src/main/java/com/novoda/merlin/internal/MerlinsBeard.kt
+++ b/library/src/main/java/com/novoda/merlin/internal/MerlinsBeard.kt
@@ -8,7 +8,7 @@ import android.os.Build
 import com.novoda.merlin.contracts.InternetAccessCallback
 import com.novoda.merlin.contracts.MerlinsBeard
 
-class MerlinsBeard(
+internal class MerlinsBeard(
     override val connectivityManager: ConnectivityManager,
     override val androidVersion: AndroidVersion = AndroidVersion(Build.VERSION.SDK_INT)
 ) : MerlinsBeard {

--- a/library/src/main/java/com/novoda/merlin/internal/MerlinsBeard.kt
+++ b/library/src/main/java/com/novoda/merlin/internal/MerlinsBeard.kt
@@ -1,0 +1,92 @@
+package com.novoda.merlin.internal
+
+import android.annotation.TargetApi
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.os.Build
+import com.novoda.merlin.contracts.InternetAccessCallback
+import com.novoda.merlin.contracts.MerlinsBeard
+
+class MerlinsBeard(
+    override val connectivityManager: ConnectivityManager,
+    override val androidVersion: AndroidVersion = AndroidVersion(Build.VERSION.SDK_INT)
+) : MerlinsBeard {
+
+    override fun isConnected(): Boolean {
+        val networkInfo = networkInfo()
+        return networkInfo?.isConnected.orElse { false }
+    }
+
+    private fun networkInfo() = connectivityManager.activeNetworkInfo
+
+    override fun isConnectedToMobileNetwork(): Boolean {
+        return isConnectedTo(androidVersion.mobileNetworkType())
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    private fun AndroidVersion.mobileNetworkType(): Int {
+        return when (this.isLollipopOrHigher()) {
+            true -> NetworkCapabilities.TRANSPORT_CELLULAR
+            false -> ConnectivityManager.TYPE_MOBILE
+        }
+    }
+
+    private fun isConnectedTo(networkType: Int): Boolean {
+        return when (androidVersion.isLollipopOrHigher()) {
+            true -> connectedToNetworkTypeForLollipop(networkType)
+            false -> {
+                val networkInfo = connectivityManager.getNetworkInfo(networkType)
+                networkInfo?.isConnected.orElse { false }
+            }
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    private fun connectedToNetworkTypeForLollipop(networkType: Int): Boolean {
+        val networks = connectivityManager.allNetworks
+        val networkForType = networks.firstOrNull {
+            val networkCapabilities = connectivityManager.getNetworkCapabilities(it)
+            return networkCapabilities.hasTransport(networkType)
+        }
+
+        return networkForType.isConnected()
+    }
+
+    override fun isConnectedToWifi(): Boolean {
+        return isConnectedTo(androidVersion.wifiNetworkType())
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    private fun AndroidVersion.wifiNetworkType(): Int {
+        return when (this.isLollipopOrHigher()) {
+            true -> NetworkCapabilities.TRANSPORT_WIFI
+            false -> ConnectivityManager.TYPE_WIFI
+        }
+    }
+
+    override fun mobileNetworkSubtype(): String {
+        val networkInfo = networkInfo()
+        return if (networkInfo?.isConnected.orElse { false }) {
+            networkInfo.subtypeName
+        } else {
+            ""
+        }
+    }
+
+    override fun hasInternetAccess(callback: InternetAccessCallback) {
+        callback(false)
+    }
+
+    override fun hasInternetAccess(): Boolean {
+        return false
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    private fun Network?.isConnected(): Boolean {
+        val networkInfo = connectivityManager.getNetworkInfo(this)
+        return networkInfo?.isConnected.orElse { false }
+    }
+
+    private inline fun <T> T?.orElse(crossinline block: () -> T) = this ?: block()
+}

--- a/library/src/test/java/com/novoda/merlin/internal/MerlinsBeardTest.kt
+++ b/library/src/test/java/com/novoda/merlin/internal/MerlinsBeardTest.kt
@@ -33,7 +33,7 @@ object MerlinsBeardTest : Spek({
             val merlinsBeard = MerlinsBeard(connectivityManager)
             val mobileNetworkSubtype = merlinsBeard.mobileNetworkSubtype()
 
-            it("it is empty") {
+            it("is empty") {
                 assertThat(mobileNetworkSubtype).isEmpty()
             }
         }
@@ -56,7 +56,6 @@ object MerlinsBeardTest : Spek({
                     assertThat(connectedToWifi).isFalse()
                 }
             }
-
         }
 
         and("android version is lower than Lollipop") {
@@ -87,6 +86,7 @@ object MerlinsBeardTest : Spek({
         }
         val networkInfo: NetworkInfo = mock {
             on { isConnected }.thenReturn(true)
+            on { subtypeName }.thenReturn("")
         }
         val connectivityManager: ConnectivityManager = mock {
             on { activeNetworkInfo }.thenReturn(networkInfo)
@@ -94,6 +94,15 @@ object MerlinsBeardTest : Spek({
             on { getNetworkCapabilities(network) }.thenReturn(networkCapabilities)
             on { getNetworkInfo(network) }.thenReturn(networkInfo)
             on { getNetworkInfo(ConnectivityManager.TYPE_WIFI) }.thenReturn(networkInfo)
+        }
+
+        on("checking mobile subtype") {
+            val merlinsBeard = MerlinsBeard(connectivityManager)
+            val mobileNetworkSubtype = merlinsBeard.mobileNetworkSubtype()
+
+            it("is empty") {
+                assertThat(mobileNetworkSubtype).isEmpty()
+            }
         }
 
         and("android version is lower than Lollipop") {
@@ -158,7 +167,7 @@ object MerlinsBeardTest : Spek({
             val merlinsBeard = MerlinsBeard(connectivityManager)
             val mobileNetworkSubtype = merlinsBeard.mobileNetworkSubtype()
 
-            it("is is subtype") {
+            it("is subtype") {
                 assertThat(mobileNetworkSubtype).isEqualTo("subtype")
             }
         }

--- a/library/src/test/java/com/novoda/merlin/internal/MerlinsBeardTest.kt
+++ b/library/src/test/java/com/novoda/merlin/internal/MerlinsBeardTest.kt
@@ -1,0 +1,172 @@
+package com.novoda.merlin.internal
+
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkInfo
+import android.os.Build
+import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockito_kotlin.mock
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.SpecBody
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
+import org.junit.platform.runner.JUnitPlatform
+import org.junit.runner.RunWith
+
+@RunWith(JUnitPlatform::class)
+object MerlinsBeardTest : Spek({
+
+    given("No network information available") {
+        val connectivityManager: ConnectivityManager = mock {
+            on { allNetworks }.thenReturn(emptyArray())
+        }
+
+        on("checking if connected") {
+            val merlinsBeard = MerlinsBeard(connectivityManager)
+            val connected = merlinsBeard.isConnected()
+
+            it("is not connected") {
+                assertThat(connected).isFalse()
+            }
+        }
+
+        and("android version is Lollipop or higher") {
+            val merlinsBeard = MerlinsBeard(connectivityManager, AndroidVersion(Build.VERSION_CODES.LOLLIPOP))
+
+            on("checking if connected to mobile network") {
+                val connectedToMobileNetwork = merlinsBeard.isConnectedToMobileNetwork()
+
+                it("is not connected") {
+                    assertThat(connectedToMobileNetwork).isFalse()
+                }
+            }
+
+            on("checking if connected to wifi network") {
+                val connectedToWifi = merlinsBeard.isConnectedToWifi()
+
+                it("is not connected") {
+                    assertThat(connectedToWifi).isFalse()
+                }
+            }
+
+        }
+
+        and("android version is lower than Lollipop") {
+            val merlinsBeard = MerlinsBeard(connectivityManager, AndroidVersion(Build.VERSION_CODES.KITKAT))
+
+            on("checking if connected to mobile network") {
+                val connectedToMobileNetwork = merlinsBeard.isConnectedToMobileNetwork()
+
+                it("is not connected") {
+                    assertThat(connectedToMobileNetwork).isFalse()
+                }
+            }
+
+            on("checking if connected to wifi network") {
+                val connectedToWifi = merlinsBeard.isConnectedToWifi()
+
+                it("is not connected") {
+                    assertThat(connectedToWifi).isFalse()
+                }
+            }
+        }
+    }
+
+    given("Connected to Wifi") {
+        val network: Network = mock()
+        val networkCapabilities: NetworkCapabilities = mock {
+            on { hasTransport(NetworkCapabilities.TRANSPORT_WIFI) }.thenReturn(true)
+        }
+        val networkInfo: NetworkInfo = mock {
+            on { isConnected }.thenReturn(true)
+        }
+        val connectivityManager: ConnectivityManager = mock {
+            on { activeNetworkInfo }.thenReturn(networkInfo)
+            on { allNetworks }.thenReturn(Array(1) { network })
+            on { getNetworkCapabilities(network) }.thenReturn(networkCapabilities)
+            on { getNetworkInfo(network) }.thenReturn(networkInfo)
+        }
+
+        and("android version is lower than Lollipop") {
+            val merlinsBeard = MerlinsBeard(connectivityManager, AndroidVersion(Build.VERSION_CODES.KITKAT))
+
+            on("checking if connected to mobile network") {
+                val connectedToMobileNetwork = merlinsBeard.isConnectedToMobileNetwork()
+
+                it("is not connected") {
+                    assertThat(connectedToMobileNetwork).isFalse()
+                }
+            }
+
+            on("checking if connected to wifi network") {
+                val connectedToWifi = merlinsBeard.isConnectedToWifi()
+
+                it("is not connected") {
+                    assertThat(connectedToWifi).isFalse()
+                }
+            }
+        }
+
+        and("android version is Lollipop or higher") {
+            val merlinsBeard = MerlinsBeard(connectivityManager, AndroidVersion(Build.VERSION_CODES.LOLLIPOP))
+
+            on("checking if connected to mobile network") {
+                val connectedToMobileNetwork = merlinsBeard.isConnectedToMobileNetwork()
+
+                it("is not connected") {
+                    assertThat(connectedToMobileNetwork).isFalse()
+                }
+            }
+
+            on("checking if connected to wifi network") {
+                val connectedToWifi = merlinsBeard.isConnectedToWifi()
+
+                it("is connected") {
+                    assertThat(connectedToWifi).isTrue()
+                }
+            }
+        }
+    }
+
+    given("Connected to Wifi") {
+        val network: Network = mock()
+        val networkCapabilities: NetworkCapabilities = mock {
+            on { hasTransport(NetworkCapabilities.TRANSPORT_WIFI) }.thenReturn(true)
+        }
+        val networkInfo: NetworkInfo = mock {
+            on { isConnected }.thenReturn(true)
+        }
+        val connectivityManager: ConnectivityManager = mock {
+            on { activeNetworkInfo }.thenReturn(networkInfo)
+            on { allNetworks }.thenReturn(Array(1) { network })
+            on { getNetworkCapabilities(network) }.thenReturn(networkCapabilities)
+            on { getNetworkInfo(network) }.thenReturn(networkInfo)
+        }
+
+        and("android version is Lollipop or higher") {
+            val merlinsBeard = MerlinsBeard(connectivityManager, AndroidVersion(Build.VERSION_CODES.LOLLIPOP))
+
+            on("checking if connected to mobile network") {
+                val connectedToMobileNetwork = merlinsBeard.isConnectedToMobileNetwork()
+
+                it("is not connected") {
+                    assertThat(connectedToMobileNetwork).isFalse()
+                }
+            }
+
+            on("checking if connected to wifi network") {
+                val connectedToWifi = merlinsBeard.isConnectedToWifi()
+
+                it("is connected") {
+                    assertThat(connectedToWifi).isTrue()
+                }
+            }
+        }
+    }
+})
+
+fun SpecBody.and(description: String, body: SpecBody.() -> Unit) {
+    group("and $description", body = body)
+}

--- a/library/src/test/java/com/novoda/merlin/internal/MerlinsBeardTest.kt
+++ b/library/src/test/java/com/novoda/merlin/internal/MerlinsBeardTest.kt
@@ -29,6 +29,15 @@ object MerlinsBeardTest : Spek({
             }
         }
 
+        on("checking mobile subtype") {
+            val merlinsBeard = MerlinsBeard(connectivityManager)
+            val mobileNetworkSubtype = merlinsBeard.mobileNetworkSubtype()
+
+            it("it is empty") {
+                assertThat(mobileNetworkSubtype).isEmpty()
+            }
+        }
+
         and("android version is Lollipop or higher") {
             val merlinsBeard = MerlinsBeard(connectivityManager, AndroidVersion(Build.VERSION_CODES.LOLLIPOP))
 
@@ -135,6 +144,7 @@ object MerlinsBeardTest : Spek({
         }
         val networkInfo: NetworkInfo = mock {
             on { isConnected }.thenReturn(true)
+            on { subtypeName }.thenReturn("subtype")
         }
         val connectivityManager: ConnectivityManager = mock {
             on { activeNetworkInfo }.thenReturn(networkInfo)
@@ -142,6 +152,15 @@ object MerlinsBeardTest : Spek({
             on { getNetworkCapabilities(network) }.thenReturn(networkCapabilities)
             on { getNetworkInfo(network) }.thenReturn(networkInfo)
             on { getNetworkInfo(ConnectivityManager.TYPE_MOBILE) }.thenReturn(networkInfo)
+        }
+
+        on("checking mobile subtype") {
+            val merlinsBeard = MerlinsBeard(connectivityManager)
+            val mobileNetworkSubtype = merlinsBeard.mobileNetworkSubtype()
+
+            it("is is subtype") {
+                assertThat(mobileNetworkSubtype).isEqualTo("subtype")
+            }
         }
 
         and("android version is lower than Lollipop") {

--- a/library/src/test/java/com/novoda/merlin/internal/MerlinsBeardTest.kt
+++ b/library/src/test/java/com/novoda/merlin/internal/MerlinsBeardTest.kt
@@ -12,10 +12,7 @@ import org.jetbrains.spek.api.dsl.SpecBody
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.api.dsl.on
-import org.junit.platform.runner.JUnitPlatform
-import org.junit.runner.RunWith
 
-@RunWith(JUnitPlatform::class)
 object MerlinsBeardTest : Spek({
 
     given("No network information available") {
@@ -87,6 +84,7 @@ object MerlinsBeardTest : Spek({
             on { allNetworks }.thenReturn(Array(1) { network })
             on { getNetworkCapabilities(network) }.thenReturn(networkCapabilities)
             on { getNetworkInfo(network) }.thenReturn(networkInfo)
+            on { getNetworkInfo(ConnectivityManager.TYPE_WIFI) }.thenReturn(networkInfo)
         }
 
         and("android version is lower than Lollipop") {
@@ -103,8 +101,8 @@ object MerlinsBeardTest : Spek({
             on("checking if connected to wifi network") {
                 val connectedToWifi = merlinsBeard.isConnectedToWifi()
 
-                it("is not connected") {
-                    assertThat(connectedToWifi).isFalse()
+                it("is connected") {
+                    assertThat(connectedToWifi).isTrue()
                 }
             }
         }
@@ -130,10 +128,10 @@ object MerlinsBeardTest : Spek({
         }
     }
 
-    given("Connected to Wifi") {
+    given("Connected to Mobile Network") {
         val network: Network = mock()
         val networkCapabilities: NetworkCapabilities = mock {
-            on { hasTransport(NetworkCapabilities.TRANSPORT_WIFI) }.thenReturn(true)
+            on { hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) }.thenReturn(true)
         }
         val networkInfo: NetworkInfo = mock {
             on { isConnected }.thenReturn(true)
@@ -143,6 +141,27 @@ object MerlinsBeardTest : Spek({
             on { allNetworks }.thenReturn(Array(1) { network })
             on { getNetworkCapabilities(network) }.thenReturn(networkCapabilities)
             on { getNetworkInfo(network) }.thenReturn(networkInfo)
+            on { getNetworkInfo(ConnectivityManager.TYPE_MOBILE) }.thenReturn(networkInfo)
+        }
+
+        and("android version is lower than Lollipop") {
+            val merlinsBeard = MerlinsBeard(connectivityManager, AndroidVersion(Build.VERSION_CODES.KITKAT))
+
+            on("checking if connected to mobile network") {
+                val connectedToMobileNetwork = merlinsBeard.isConnectedToMobileNetwork()
+
+                it("is connected") {
+                    assertThat(connectedToMobileNetwork).isTrue()
+                }
+            }
+
+            on("checking if connected to wifi network") {
+                val connectedToWifi = merlinsBeard.isConnectedToWifi()
+
+                it("is not connected") {
+                    assertThat(connectedToWifi).isFalse()
+                }
+            }
         }
 
         and("android version is Lollipop or higher") {
@@ -151,16 +170,16 @@ object MerlinsBeardTest : Spek({
             on("checking if connected to mobile network") {
                 val connectedToMobileNetwork = merlinsBeard.isConnectedToMobileNetwork()
 
-                it("is not connected") {
-                    assertThat(connectedToMobileNetwork).isFalse()
+                it("is connected") {
+                    assertThat(connectedToMobileNetwork).isTrue()
                 }
             }
 
             on("checking if connected to wifi network") {
                 val connectedToWifi = merlinsBeard.isConnectedToWifi()
 
-                it("is connected") {
-                    assertThat(connectedToWifi).isTrue()
+                it("is not connected") {
+                    assertThat(connectedToWifi).isFalse()
                 }
             }
         }


### PR DESCRIPTION
x Dependent on #189  DO NOT MERGE x

## Problem
`MerlinsBeard` is just currently an interface and the demo is using hardcoded response strings for user feedback. We should start making some real calls. 

## Solution
Use the `Spek` testing framework for `MerlinsBeard` and implements all functions bar the `hasInternetAccess` func, it will require an actual network call which would be good to also test. This will be done in a follow-up PR. 

I've hooked up the `DemoActivity` to the associated methods and used the real strings that are in resources.

### Test(s) added
Yes, `MerlinsBeard` is nearly completely tested, see above. 

### Paired with
Nobody. 
