### PR TITLE
Removing Jetifier config

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,0 @@
-android.enableJetifier=true
-android.useAndroidX=true


### PR DESCRIPTION
## Problem

Including this library forces clients to transitively rely on the Jetifier process, which isn't needed since there's no legacy support libraries!

## Solution
To remove the jetifier/androidX properties

### Test(s) added
N/A since it's build related
